### PR TITLE
Tunnel configuration first cut

### DIFF
--- a/ngrok/examples/connect.rs
+++ b/ngrok/examples/connect.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use futures::TryStreamExt;
 use ngrok::{
     Session,
-    Tunnel, TCPEndpoint,
+    TCPEndpoint,
+    Tunnel,
 };
 use tokio::io::{
     self,
@@ -22,15 +23,20 @@ async fn main() -> anyhow::Result<()> {
         .with_env_filter(std::env::var("RUST_LOG").unwrap_or_default())
         .init();
 
-    let sess = Arc::new(Session::new()
-        .with_authtoken_from_env()
-        .with_metadata("Online in One Line")
-        .connect()
-        .await?);
+    let sess = Arc::new(
+        Session::new()
+            .with_authtoken_from_env()
+            .with_metadata("Online in One Line")
+            .connect()
+            .await?,
+    );
 
-    let tunnel = sess.start_tunnel(TCPEndpoint::default()
-        .with_metadata("Understand it so thoroughly that you merge with it")
-        ).await?;
+    let tunnel = sess
+        .start_tunnel(
+            TCPEndpoint::default()
+                .with_metadata("Understand it so thoroughly that you merge with it"),
+        )
+        .await?;
 
     handle_tunnel(tunnel, sess);
 

--- a/ngrok/examples/connect_http.rs
+++ b/ngrok/examples/connect_http.rs
@@ -2,8 +2,9 @@ use std::sync::Arc;
 
 use futures::TryStreamExt;
 use ngrok::{
+    HTTPEndpoint,
     Session,
-    Tunnel, HTTPEndpoint,
+    Tunnel,
 };
 use tokio::io::{
     self,
@@ -22,15 +23,20 @@ async fn main() -> anyhow::Result<()> {
         .with_env_filter(std::env::var("RUST_LOG").unwrap_or_default())
         .init();
 
-    let sess = Arc::new(Session::new()
-        .with_authtoken_from_env()
-        .with_metadata("Online in One Line")
-        .connect()
-        .await?);
+    let sess = Arc::new(
+        Session::new()
+            .with_authtoken_from_env()
+            .with_metadata("Online in One Line")
+            .connect()
+            .await?,
+    );
 
-    let tunnel = sess.start_tunnel(HTTPEndpoint::default()
-        .with_metadata("Understand it so thoroughly that you merge with it")
-        ).await?;
+    let tunnel = sess
+        .start_tunnel(
+            HTTPEndpoint::default()
+                .with_metadata("Understand it so thoroughly that you merge with it"),
+        )
+        .await?;
 
     handle_tunnel(tunnel, sess);
 
@@ -66,7 +72,11 @@ fn handle_tunnel(mut tunnel: Tunnel, sess: Arc<Session>) {
 
                     if buf.eq("\r\n".into()) {
                         info!("writing");
-                        tx.write_all("HTTP/1.1 200 OK\r\n\r\n<html><body>hi</body></html>\r\n\r\n".as_bytes()).await?;
+                        tx.write_all(
+                            "HTTP/1.1 200 OK\r\n\r\n<html><body>hi</body></html>\r\n\r\n"
+                                .as_bytes(),
+                        )
+                        .await?;
                         info!("done writing");
                         tx.flush().await?;
                         info!("connection shutdown");

--- a/ngrok/src/config/common.rs
+++ b/ngrok/src/config/common.rs
@@ -18,7 +18,10 @@ impl<T> TunnelConfig for T where T: private::TunnelConfigPrivate {}
 pub(crate) mod private {
     use std::collections::HashMap;
 
-    use crate::{internals::proto::{BindExtra, BindOpts}};
+    use crate::internals::proto::{
+        BindExtra,
+        BindOpts,
+    };
 
     // This is the internal-only interface that all config.Tunnel implementations
     // *also* implement. This lets us pull the necessary bits out of it without
@@ -28,25 +31,51 @@ pub(crate) mod private {
         fn extra(&self) -> BindExtra;
         fn proto(&self) -> String;
         fn opts(&self) -> Option<BindOpts>;
-        fn labels(&self) -> HashMap<String,String>;
+        fn labels(&self) -> HashMap<String, String>;
     }
 
     // delegate references
-    impl<'a, T> TunnelConfigPrivate for &'a T where T: TunnelConfigPrivate {
-        fn forwards_to(&self) -> String { (**self).forwards_to() }
-        fn extra(&self) -> BindExtra { (**self).extra() }
-        fn proto(&self) -> String { (**self).proto() }
-        fn opts(&self) -> Option<BindOpts> { (**self).opts() }
-        fn labels(&self) -> HashMap<String,String> { (**self).labels() }
+    impl<'a, T> TunnelConfigPrivate for &'a T
+    where
+        T: TunnelConfigPrivate,
+    {
+        fn forwards_to(&self) -> String {
+            (**self).forwards_to()
+        }
+        fn extra(&self) -> BindExtra {
+            (**self).extra()
+        }
+        fn proto(&self) -> String {
+            (**self).proto()
+        }
+        fn opts(&self) -> Option<BindOpts> {
+            (**self).opts()
+        }
+        fn labels(&self) -> HashMap<String, String> {
+            (**self).labels()
+        }
     }
 
     // delegate mutable references
-    impl<'a, T> TunnelConfigPrivate for &'a mut T where T: TunnelConfigPrivate {
-        fn forwards_to(&self) -> String { (**self).forwards_to() }
-        fn extra(&self) -> BindExtra { (**self).extra() }
-        fn proto(&self) -> String { (**self).proto() }
-        fn opts(&self) -> Option<BindOpts> { (**self).opts() }
-        fn labels(&self) -> HashMap<String,String> { (**self).labels() }
+    impl<'a, T> TunnelConfigPrivate for &'a mut T
+    where
+        T: TunnelConfigPrivate,
+    {
+        fn forwards_to(&self) -> String {
+            (**self).forwards_to()
+        }
+        fn extra(&self) -> BindExtra {
+            (**self).extra()
+        }
+        fn proto(&self) -> String {
+            (**self).proto()
+        }
+        fn opts(&self) -> Option<BindOpts> {
+            (**self).opts()
+        }
+        fn labels(&self) -> HashMap<String, String> {
+            (**self).labels()
+        }
     }
 }
 
@@ -56,16 +85,16 @@ pub struct CidrRestrictions {
 
 // Common
 pub(crate) struct CommonOpts {
-	// Restrictions placed on the origin of incoming connections to the edge.
-	pub(crate) cidr_restrictions: Option<CidrRestrictions>,
-	// The version of PROXY protocol to use with this tunnel, zero if not
-	// using.
-	pub(crate) proxy_proto: Option<ProxyProto>,
-	// Tunnel-specific opaque metadata. Viewable via the API.
-	pub(crate) metadata: Option<String>,
-	// Tunnel backend metadata. Viewable via the dashboard and API, but has no
-	// bearing on tunnel behavior.
-	pub(crate) forwards_to: Option<String>,
+    // Restrictions placed on the origin of incoming connections to the edge.
+    pub(crate) cidr_restrictions: Option<CidrRestrictions>,
+    // The version of PROXY protocol to use with this tunnel, zero if not
+    // using.
+    pub(crate) proxy_proto: Option<ProxyProto>,
+    // Tunnel-specific opaque metadata. Viewable via the API.
+    pub(crate) metadata: Option<String>,
+    // Tunnel backend metadata. Viewable via the dashboard and API, but has no
+    // bearing on tunnel behavior.
+    pub(crate) forwards_to: Option<String>,
 }
 
 impl Default for CommonOpts {

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -1,6 +1,17 @@
 use std::collections::HashMap;
 
-use crate::{common::{CommonOpts, private, FORWARDS_TO}, internals::proto::{BindExtra, BindOpts, self}};
+use crate::{
+    common::{
+        private,
+        CommonOpts,
+        FORWARDS_TO,
+    },
+    internals::proto::{
+        self,
+        BindExtra,
+        BindOpts,
+    },
+};
 
 #[derive(Clone, Eq, PartialEq)]
 pub enum Scheme {
@@ -12,7 +23,7 @@ pub struct HTTPEndpoint {
     common_opts: CommonOpts,
     scheme: Scheme,
     hostname: Option<String>,
-    basic_auth: Option<(String, String)>
+    basic_auth: Option<(String, String)>,
 }
 
 impl Default for HTTPEndpoint {
@@ -28,7 +39,10 @@ impl Default for HTTPEndpoint {
 
 impl private::TunnelConfigPrivate for HTTPEndpoint {
     fn forwards_to(&self) -> String {
-        self.common_opts.forwards_to.clone().unwrap_or(FORWARDS_TO.into())
+        self.common_opts
+            .forwards_to
+            .clone()
+            .unwrap_or(FORWARDS_TO.into())
     }
     fn extra(&self) -> BindExtra {
         BindExtra {
@@ -53,7 +67,7 @@ impl private::TunnelConfigPrivate for HTTPEndpoint {
 
         Some(BindOpts::HTTPEndpoint(http_endpoint))
     }
-    fn labels(&self) -> HashMap<String,String> {
+    fn labels(&self) -> HashMap<String, String> {
         return HashMap::new();
     }
 }
@@ -63,14 +77,18 @@ impl HTTPEndpoint {
         self.common_opts.metadata = Some(metadata.into());
         self
     }
-	pub fn with_hostname(&mut self, hostname: impl Into<String>) -> &mut Self {
+    pub fn with_hostname(&mut self, hostname: impl Into<String>) -> &mut Self {
         self.hostname = Some(hostname.into());
         self
     }
-	pub fn with_basic_auth(&mut self, username: impl Into<String>, password: impl Into<String>) -> &mut Self {
+    pub fn with_basic_auth(
+        &mut self,
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> &mut Self {
         self.basic_auth = Some((username.into(), password.into()));
         self
     }
 
-	// todo
+    // todo
 }

--- a/ngrok/src/config/labeled.rs
+++ b/ngrok/src/config/labeled.rs
@@ -1,6 +1,16 @@
 use std::collections::HashMap;
 
-use crate::{common::{CommonOpts, private, FORWARDS_TO}, internals::proto::{BindExtra, BindOpts}};
+use crate::{
+    common::{
+        private,
+        CommonOpts,
+        FORWARDS_TO,
+    },
+    internals::proto::{
+        BindExtra,
+        BindOpts,
+    },
+};
 
 pub struct LabeledTunnel {
     common_opts: CommonOpts,
@@ -16,7 +26,10 @@ impl Default for LabeledTunnel {
 
 impl private::TunnelConfigPrivate for LabeledTunnel {
     fn forwards_to(&self) -> String {
-        self.common_opts.forwards_to.clone().unwrap_or(FORWARDS_TO.into())
+        self.common_opts
+            .forwards_to
+            .clone()
+            .unwrap_or(FORWARDS_TO.into())
     }
     fn extra(&self) -> BindExtra {
         BindExtra {
@@ -25,11 +38,13 @@ impl private::TunnelConfigPrivate for LabeledTunnel {
             metadata: self.common_opts.metadata.clone().unwrap_or_default(),
         }
     }
-    fn proto(&self) -> String {"".into()}
+    fn proto(&self) -> String {
+        "".into()
+    }
     fn opts(&self) -> Option<BindOpts> {
         None
     }
-    fn labels(&self) -> HashMap<String,String> {
+    fn labels(&self) -> HashMap<String, String> {
         return HashMap::new();
     }
 }

--- a/ngrok/src/config/tcp.rs
+++ b/ngrok/src/config/tcp.rs
@@ -1,6 +1,17 @@
 use std::collections::HashMap;
 
-use crate::{common::{CommonOpts, FORWARDS_TO, private}, internals::proto::{BindExtra, BindOpts, self}};
+use crate::{
+    common::{
+        private,
+        CommonOpts,
+        FORWARDS_TO,
+    },
+    internals::proto::{
+        self,
+        BindExtra,
+        BindOpts,
+    },
+};
 
 pub struct TCPEndpoint {
     pub(crate) common_opts: CommonOpts,
@@ -16,7 +27,10 @@ impl Default for TCPEndpoint {
 
 impl private::TunnelConfigPrivate for TCPEndpoint {
     fn forwards_to(&self) -> String {
-        self.common_opts.forwards_to.clone().unwrap_or(FORWARDS_TO.into())
+        self.common_opts
+            .forwards_to
+            .clone()
+            .unwrap_or(FORWARDS_TO.into())
     }
     fn extra(&self) -> BindExtra {
         BindExtra {
@@ -25,7 +39,9 @@ impl private::TunnelConfigPrivate for TCPEndpoint {
             metadata: self.common_opts.metadata.clone().unwrap_or_default(),
         }
     }
-    fn proto(&self) -> String {"tcp".into()}
+    fn proto(&self) -> String {
+        "tcp".into()
+    }
     fn opts(&self) -> Option<BindOpts> {
         // fill out all the options here, translating to proto here
         let mut tcp_endpoint = proto::TCPEndpoint::default();
@@ -36,7 +52,7 @@ impl private::TunnelConfigPrivate for TCPEndpoint {
 
         Some(BindOpts::TCPEndpoint(tcp_endpoint))
     }
-    fn labels(&self) -> HashMap<String,String> {
+    fn labels(&self) -> HashMap<String, String> {
         return HashMap::new();
     }
 }

--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -1,6 +1,17 @@
 use std::collections::HashMap;
 
-use crate::{common::{CommonOpts, private, FORWARDS_TO}, internals::proto::{BindExtra, BindOpts, self}};
+use crate::{
+    common::{
+        private,
+        CommonOpts,
+        FORWARDS_TO,
+    },
+    internals::proto::{
+        self,
+        BindExtra,
+        BindOpts,
+    },
+};
 
 pub struct TLSEndpoint {
     common_opts: CommonOpts,
@@ -16,7 +27,10 @@ impl Default for TLSEndpoint {
 
 impl private::TunnelConfigPrivate for TLSEndpoint {
     fn forwards_to(&self) -> String {
-        self.common_opts.forwards_to.clone().unwrap_or(FORWARDS_TO.into())
+        self.common_opts
+            .forwards_to
+            .clone()
+            .unwrap_or(FORWARDS_TO.into())
     }
     fn extra(&self) -> BindExtra {
         BindExtra {
@@ -25,7 +39,9 @@ impl private::TunnelConfigPrivate for TLSEndpoint {
             metadata: self.common_opts.metadata.clone().unwrap_or_default(),
         }
     }
-    fn proto(&self) -> String {"tls".into()}
+    fn proto(&self) -> String {
+        "tls".into()
+    }
     fn opts(&self) -> Option<BindOpts> {
         // fill out all the options here, translating to proto here
         let mut tls_endpoint = proto::TLSEndpoint::default();
@@ -36,7 +52,7 @@ impl private::TunnelConfigPrivate for TLSEndpoint {
 
         Some(BindOpts::TLSEndpoint(tls_endpoint))
     }
-    fn labels(&self) -> HashMap<String,String> {
+    fn labels(&self) -> HashMap<String, String> {
         return HashMap::new();
     }
 }

--- a/ngrok/src/internals/raw_session.rs
+++ b/ngrok/src/internals/raw_session.rs
@@ -3,7 +3,10 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{Error, bail};
+use anyhow::{
+    bail,
+    Error,
+};
 use muxado::{
     heartbeat::HeartbeatConfig,
     session::SessionBuilder,
@@ -33,10 +36,11 @@ use super::{
         StartTunnelWithLabelResp,
         Unbind,
         UnbindResp,
+        PROXY_REQ,
         RESTART_REQ,
         STOP_REQ,
         UPDATE_REQ,
-        VERSION, PROXY_REQ,
+        VERSION,
     },
     rpc::RPCRequest,
 };
@@ -150,7 +154,7 @@ impl RawSession {
                     let header = ProxyHeader::read_from_stream(&mut *stream).await?;
 
                     break TunnelStream { header, stream };
-                },
+                }
                 t => bail!("invalid stream type: {}", t),
             }
         })

--- a/ngrok/src/lib.rs
+++ b/ngrok/src/lib.rs
@@ -20,10 +20,12 @@ mod config {
 mod session;
 mod tunnel;
 
-pub use config::*;
-pub use config::http::*;
-pub use config::labeled::*;
-pub use config::tcp::*;
-pub use config::tls::*;
+pub use config::{
+    http::*,
+    labeled::*,
+    tcp::*,
+    tls::*,
+    *,
+};
 pub use session::*;
 pub use tunnel::*;

--- a/ngrok/src/tunnel.rs
+++ b/ngrok/src/tunnel.rs
@@ -1,10 +1,11 @@
 use std::{
+    collections::HashMap,
     pin::Pin,
     sync::Arc,
     task::{
         Context,
         Poll,
-    }, collections::HashMap,
+    },
 };
 
 use futures::{
@@ -24,7 +25,9 @@ use tokio::{
 
 use crate::internals::{
     proto::{
-        ProxyHeader, BindOpts, BindExtra,
+        BindExtra,
+        BindOpts,
+        ProxyHeader,
     },
     raw_session::{
         RawSession,
@@ -72,11 +75,7 @@ impl Tunnel {
     }
 
     pub async fn close(&mut self) -> anyhow::Result<()> {
-        self.sess
-            .lock()
-            .await
-            .unlisten(&self.id)
-            .await?;
+        self.sess.lock().await.unlisten(&self.id).await?;
         self.incoming.close();
         Ok(())
     }


### PR DESCRIPTION
Wanted to float this by you to see if it's in the right direction. This is able to plumb tunnel metadata through, get a http tunnel going, and has scaffolding for configuring the four tunnel types. There are still a ton of settings to add so I'll keep chugging through putting in all of the rest. I had to fight with the trait sealing, that's currently different than you spec'd out so I could make progress. Let me know what changes you'd like!

Looks like this repo doesn't allow draft PR's, maybe they could be turned on? 