### PR TITLE
tunnels: flesh out api, hyper+axum integration+example

### DIFF
--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -16,9 +16,12 @@ tracing = "0.1.29"
 async-rustls = { version = "0.2.0", features = ["dangerous_configuration"] }
 tokio-util = { version = "0.7.4", features = ["compat"] }
 futures = "0.3.25"
+hyper = { version = "0.14.23", features = ["server"] }
+axum = { version = "0.6.1", features = ["tokio"] }
 
 [build-dependencies]
 prost-build = "0.11.1"
 
 [dev-dependencies]
+axum = "0.6.1"
 tracing-subscriber = "0.3.16"

--- a/ngrok/examples/axum.rs
+++ b/ngrok/examples/axum.rs
@@ -1,0 +1,48 @@
+use std::net::SocketAddr;
+
+use axum::{
+    extract::ConnectInfo,
+    routing::get,
+    Router,
+};
+use ngrok::{
+    HTTPEndpoint,
+    Session,
+    Tunnel,
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // build our application with a single route
+    let app = Router::new().route(
+        "/",
+        get(
+            |ConnectInfo(remote_addr): ConnectInfo<SocketAddr>| async move {
+                format!("Hello, {:?}!\r\n", remote_addr)
+            },
+        ),
+    );
+
+    // run it with hyper on localhost:8000
+    // axum::Server::bind(&"0.0.0.0:8000".parse().unwrap())
+    // Or with an ngrok tunnel
+    axum::Server::builder(start_tunnel().await?)
+        .serve(app.into_make_service_with_connect_info::<SocketAddr>())
+        .await
+        .unwrap();
+
+    Ok(())
+}
+
+async fn start_tunnel() -> anyhow::Result<Tunnel> {
+    let sess = Session::builder()
+        .with_authtoken_from_env()
+        .connect()
+        .await?;
+
+    let tun = sess.start_tunnel(HTTPEndpoint::default()).await?;
+
+    println!("Tunnel started on URL: {:?}", tun.url());
+
+    Ok(tun)
+}

--- a/ngrok/examples/connect.rs
+++ b/ngrok/examples/connect.rs
@@ -58,7 +58,7 @@ fn handle_tunnel(mut tunnel: Tunnel, sess: Arc<Session>) {
             let id: String = tunnel.id().into();
 
             tokio::spawn(async move {
-                info!("accepted connection: {:?}", stream.header());
+                info!("accepted connection: {:?}", stream.remote_addr());
                 let (rx, mut tx) = io::split(stream);
 
                 let mut lines = BufReader::new(rx);

--- a/ngrok/examples/connect_http.rs
+++ b/ngrok/examples/connect_http.rs
@@ -58,7 +58,7 @@ fn handle_tunnel(mut tunnel: Tunnel, sess: Arc<Session>) {
             let _id: String = tunnel.id().into();
 
             tokio::spawn(async move {
-                info!("accepted connection: {:?}", stream.header());
+                info!("accepted connection: {:?}", stream.remote_addr());
                 let (rx, mut tx) = io::split(stream);
 
                 let mut lines = BufReader::new(rx);

--- a/ngrok/src/internals/rpc.rs
+++ b/ngrok/src/internals/rpc.rs
@@ -4,14 +4,14 @@ use serde::{
     Serialize,
 };
 
-pub trait RPCRequest: Serialize {
+pub trait RpcRequest: Serialize {
     type Response: DeserializeOwned;
     const TYPE: StreamType;
 }
 
 macro_rules! rpc_req {
     ($req:ty, $resp:ty, $typ:expr) => {
-        impl $crate::internals::rpc::RPCRequest for $req {
+        impl $crate::internals::rpc::RpcRequest for $req {
             type Response = $resp;
             const TYPE: StreamType = $typ;
         }

--- a/ngrok/src/tunnel.rs
+++ b/ngrok/src/tunnel.rs
@@ -1,92 +1,129 @@
-// TODO: remove this once the Tunnel type is fully fleshed out.
-#![allow(dead_code)]
-
 use std::{
     collections::HashMap,
+    net::SocketAddr,
     pin::Pin,
-    sync::Arc,
     task::{
         Context,
         Poll,
     },
 };
 
+use axum::extract::connect_info::Connected;
 use futures::{
     Stream,
     TryStreamExt,
 };
+use hyper::server::accept::Accept;
+use muxado::typed::TypedStream;
 use tokio::{
     io::{
         AsyncRead,
         AsyncWrite,
     },
-    sync::{
-        mpsc::Receiver,
-        Mutex,
-    },
+    sync::mpsc::Receiver,
 };
 
-use crate::internals::{
-    proto::{
+use crate::{
+    internals::proto::{
         BindExtra,
         BindOpts,
-        ProxyHeader,
     },
-    raw_session::{
-        RpcClient,
-        TunnelStream,
-    },
+    Session,
 };
 
 pub struct Tunnel {
     pub(crate) id: String,
-    pub(crate) config_proto: String,
+    pub(crate) proto: String,
     pub(crate) url: String,
-    pub(crate) opts: Option<BindOpts>,
-    pub(crate) token: String,
-    pub(crate) bind_extra: BindExtra,
     pub(crate) labels: HashMap<String, String>,
     pub(crate) forwards_to: String,
-    pub(crate) client: Arc<Mutex<RpcClient>>,
+    pub(crate) session: Session,
     pub(crate) incoming: Receiver<anyhow::Result<Conn>>,
+
+    // TODO: remove these allows once we start using these, or the fields if we
+    //       decide we don't need them.
+    #[allow(dead_code)]
+    pub(crate) opts: Option<BindOpts>,
+    #[allow(dead_code)]
+    pub(crate) token: String,
+    #[allow(dead_code)]
+    pub(crate) bind_extra: BindExtra,
 }
 
 pub struct Conn {
-    pub(crate) inner: TunnelStream,
+    pub(crate) remote_addr: SocketAddr,
+    pub(crate) stream: TypedStream,
 }
 
+// TODO: real error type
+pub type AcceptError = anyhow::Error;
+pub type CloseError = anyhow::Error;
+
 impl Stream for Tunnel {
-    type Item = Result<Conn, anyhow::Error>;
+    type Item = Result<Conn, AcceptError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.incoming.poll_recv(cx)
     }
 }
 
+impl Accept for Tunnel {
+    type Conn = Conn;
+    type Error = AcceptError;
+
+    fn poll_accept(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
+        self.poll_next(cx)
+    }
+}
+
 impl Tunnel {
     /// Accept an incomming connection on this tunnel.
-    pub async fn accept(&mut self) -> anyhow::Result<Option<Conn>> {
+    pub async fn accept(&mut self) -> Result<Option<Conn>, AcceptError> {
         self.try_next().await
     }
 
+    /// Get this tunnel's ID as returned by the ngrok server.
     pub fn id(&self) -> &str {
         &self.id
     }
 
+    /// Get the URL for this tunnel.
+    /// Labeled tunnels will return an empty string.
     pub fn url(&self) -> &str {
         &self.url
     }
 
-    pub async fn close(&mut self) -> anyhow::Result<()> {
-        self.client.lock().await.unlisten(&self.id).await?;
+    /// Close the tunnel.
+    /// This is an RPC call and needs to be `.await`ed.
+    pub async fn close(&mut self) -> Result<(), CloseError> {
+        self.session.close_tunnel(&self.id).await?;
         self.incoming.close();
         Ok(())
+    }
+
+    /// Get the protocol that this tunnel uses.
+    pub fn proto(&self) -> &str {
+        &self.proto
+    }
+
+    /// Get the labels this tunnel was started with.
+    /// The returned [`HashMap`] will be empty for non-labeled tunnels.
+    pub fn labels(&self) -> &HashMap<String, String> {
+        &self.labels
+    }
+
+    /// Get the address that this tunnel says it forwards to.
+    pub fn forwards_to(&self) -> &str {
+        &self.forwards_to
     }
 }
 
 impl Conn {
-    pub fn header(&self) -> &ProxyHeader {
-        &self.inner.header
+    pub fn remote_addr(&self) -> SocketAddr {
+        self.remote_addr
     }
 }
 
@@ -96,7 +133,7 @@ impl AsyncRead for Conn {
         cx: &mut Context<'_>,
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut *self.inner.stream).poll_read(cx, buf)
+        Pin::new(&mut *self.stream).poll_read(cx, buf)
     }
 }
 
@@ -106,18 +143,24 @@ impl AsyncWrite for Conn {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, std::io::Error>> {
-        Pin::new(&mut *self.inner.stream).poll_write(cx, buf)
+        Pin::new(&mut *self.stream).poll_write(cx, buf)
     }
     fn poll_flush(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), std::io::Error>> {
-        Pin::new(&mut *self.inner.stream).poll_flush(cx)
+        Pin::new(&mut *self.stream).poll_flush(cx)
     }
     fn poll_shutdown(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), std::io::Error>> {
-        Pin::new(&mut *self.inner.stream).poll_shutdown(cx)
+        Pin::new(&mut *self.stream).poll_shutdown(cx)
+    }
+}
+
+impl Connected<&Conn> for SocketAddr {
+    fn connect_info(target: &Conn) -> Self {
+        target.remote_addr
     }
 }


### PR DESCRIPTION
We'll probably want to hide some of this behind feature flags so that it's not *always* compiled, but it's probably easiest to skip that for now for ease of development.

As usual, there's some miscellaneous cleanup in there as well because I can't help myself :stuck_out_tongue: 