### PR TITLE
ci: test the result of merging PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 on:
   push:
-    branches: [main]
+    branches: [develop]
   pull_request:
-    branches: [main]
+    branches: [develop]
 
 name: Continuous integration
 


### PR DESCRIPTION
Our previous `on: [push]` only tested the current state of the branch. Now, tests will be run on pushes to `main`, and on the merged result of pull requests.