### PR TITLE
Attach source to reconnect error

### DIFF
--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngrok"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The ngrok agent SDK"

--- a/ngrok/src/tunnel.rs
+++ b/ngrok/src/tunnel.rs
@@ -47,7 +47,7 @@ pub enum AcceptError {
     Transport(#[from] MuxadoError),
     /// An error arose during reconnect
     #[error("reconnect error")]
-    Reconnect(Arc<ConnectError>),
+    Reconnect(#[from] Arc<ConnectError>),
 }
 
 pub(crate) struct TunnelInner {


### PR DESCRIPTION
This will allow checking if reconnect is cancelled, so client can know if session is closing.