### PR TITLE
Add feature Win32_Foundation, update nix for rust 1.72

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
         with:
           command: test
-          args: --features=paid-tests,long-tests --workspace --all-targets
+          args: --workspace --all-targets
 
   test-stable:
     name: Test Stable
@@ -74,6 +74,26 @@ jobs:
         with:
           command: test
           args: --features=paid-tests,long-tests --workspace --all-targets
+
+  test-win:
+    name: Test Windows Stable
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      # We don't actualy have sccache installed here (yet), but it still
+      # benefits from the cargo cache.
+      - uses: ./.github/workflows/rust-cache
+      - uses: actions-rs/cargo@v1
+        env:
+          NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
+        with:
+          command: test
+          args: --workspace --all-targets
 
   semver:
     name: Semver Check
@@ -96,7 +116,7 @@ jobs:
   publish-muxado:
     name: Publish muxado
     uses: ./.github/workflows/release.yml
-    needs: [udeps, fmt, clippy, test-nix, test-stable, semver]
+    needs: [udeps, fmt, clippy, test-nix, test-stable, test-win, semver]
     if: github.ref_name == 'main' && github.repository == 'ngrok/ngrok-rust'
     permissions:
       contents: write

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
 	"muxado",
 	"ngrok",

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1673504624,
-        "narHash": "sha256-TErLn2YuXzT5d5QTScnklfek5Gj3xAflKVx8roWsuz0=",
+        "lastModified": 1687242195,
+        "narHash": "sha256-UAmcSAe456dkgM37p5rAmoobnwSFASIjq0C/HYBY5OQ=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "6606c057b796317b26f16fc91c12524d2b6a5a11",
+        "rev": "0ed0225cee3a10ae7bd9247aef9e9709db03e1d9",
         "type": "github"
       },
       "original": {
@@ -22,12 +22,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1687171271,
+        "narHash": "sha256-BJlq+ozK2B1sJDQXS3tzJM5a+oVZmi1q0FlBK/Xqv7M=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c",
         "type": "github"
       },
       "original": {
@@ -38,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673525234,
-        "narHash": "sha256-fMP37VTeqSzC8JYoQJinLOnHfjriE5uKInLWJRz5K3E=",
+        "lastModified": 1687245362,
+        "narHash": "sha256-+f9tH+k3u9lSS136M2LCsl5NJTNPvhmHEiVOcypiu1E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "92f9580a4c369b4b51a7b6a5e77da43720134c9f",
+        "rev": "205ee073b053fc4d87d5adf2ebd44ebbef7bca4d",
         "type": "github"
       },
       "original": {
@@ -62,17 +65,32 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1673454071,
-        "narHash": "sha256-HUj+9580ig5eptFKlVylDmJ0LE/3jmQkKhf0VgjAVEo=",
+        "lastModified": 1687203733,
+        "narHash": "sha256-7waTnMILpt2nf+dOqrrCmln/5vn8uE0cBuG0HjgrRaA=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "09aceea36d790ecdd24d746c478e7d7421fa6b98",
+        "rev": "40ed61e8437801fca478281c35b2e77dc31a4b7a",
         "type": "github"
       },
       "original": {
         "owner": "rust-lang",
         "ref": "nightly",
         "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/muxado/src/stream_manager.rs
+++ b/muxado/src/stream_manager.rs
@@ -376,7 +376,7 @@ impl SharedStreamManager {
             // Lock self, look up the stream. If it doesn't exist, return the
             // error.
             let mut lock = ready!(self.0.poll_lock(cx));
-            let mut handle = match lock.get_stream(id) {
+            let handle = match lock.get_stream(id) {
                 Ok(handle) => handle,
                 Err(_e) if HeaderType::Data != typ || is_fin => {
                     return Ok(()).into();

--- a/ngrok/CHANGELOG.md
+++ b/ngrok/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.4
+
+* Add `Win32_Foundation` feature
+* Update nix for rust `1.72`
+
 ## 0.12.3
 
 * Add `session.id()`

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -31,7 +31,7 @@ hostname = "0.3.1"
 regex = "1.7.3"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = "0.45.0"
+windows-sys = { version = "0.45.0", features = ["Win32_Foundation"] }
 
 [dev-dependencies]
 tokio = { version = "1.23.0", features = ["full"] }

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngrok"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The ngrok agent SDK"


### PR DESCRIPTION
- Explicitly adding the `Win32_Foundation` feature of `windows-sys` to resolve https://github.com/ngrok/ngrok-rust/issues/99
- Adds a Windows build+test CI stage, removes long-tests from test-nix (but not test-stable) to be less-likely to trip packet blocking
- Updates nix `flake.lock`to move from rust `1.68` to `1.72` to get a clippy of at least `1.70` to pick up the now-required [let_with_type_underscore](https://rust-lang.github.io/rust-clippy/master/index.html#/let_with_type_underscore) lint
- Adds `resolver = "2"` to root `Cargo.toml` to remove resulting warn from the rust upgrade
- Removes a `mut` in [stream_manager.rs](https://github.com/ngrok/ngrok-rust/pull/101/files#diff-509c841b05c2bffa9f0cd523753190abc90adb8fef8d858bd881fc3951aff503) to appease the new clippy