### PR TITLE
ngrok: don't trim the ERR_NGROK prefix from error codes

### DIFF
--- a/ngrok/CHANGELOG.md
+++ b/ngrok/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.1
+
+- Preserve the `ERR_NGROK` prefix for error codes.
+
 ## 0.13.0
 
 - Add the `NgrokError` trait

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngrok"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The ngrok agent SDK"

--- a/ngrok/src/internals/proto.rs
+++ b/ngrok/src/internals/proto.rs
@@ -66,7 +66,7 @@ impl<'a> From<&'a str> for ErrResp {
         let mut msg_lines = vec![];
         for line in value.lines().filter(|l| !l.is_empty()) {
             if line.starts_with("ERR_NGROK_") {
-                error_code = line.split('_').nth(2).map(String::from);
+                error_code = Some(line.trim().into());
             } else {
                 msg_lines.push(line);
             }


### PR DESCRIPTION
I got this wrong - we should be including the prefix to the error codes
after all. See [this thread](https://github.com/ngrok/ngrok-go/pull/112#discussion_r1297876439) for context.
