### PR TITLE
ngrok: support connecting through either http or socks5 proxies

### DIFF
--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngrok"
-version = "0.14.0-pre.1"
+version = "0.14.0-pre.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The ngrok agent SDK"

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -29,6 +29,8 @@ parking_lot = "0.12.1"
 once_cell = "1.17.1"
 hostname = "0.3.1"
 regex = "1.7.3"
+tokio-socks = "0.5.1"
+hyper-proxy = "0.9.1"
 http = "0.2.9"
 
 [target.'cfg(windows)'.dependencies]

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -17,7 +17,7 @@ tracing = "0.1.37"
 async-rustls = { version = "0.3.0" }
 tokio-util = { version = "0.7.4", features = ["compat"] }
 futures = "0.3.25"
-hyper = { version = "0.14.23", features = ["server"], optional = true }
+hyper = { version = "0.14.23" }
 axum = { version = "0.6.1", features = ["tokio"], optional = true }
 rustls-pemfile = "1.0.1"
 async-trait = "0.1.59"
@@ -65,7 +65,7 @@ required-features = ["hyper"]
 
 [features]
 default = []
-hyper = ["dep:hyper"]
+hyper = ["hyper/server", "hyper/http1"]
 axum = ["dep:axum", "hyper"]
 online-tests = ["axum", "hyper"]
 long-tests = ["online-tests"]

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -31,7 +31,7 @@ hostname = "0.3.1"
 regex = "1.7.3"
 tokio-socks = "0.5.1"
 hyper-proxy = "0.9.1"
-http = "0.2.9"
+url = "2.4.0"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.45.0", features = ["Win32_Foundation"] }

--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -236,9 +236,7 @@ fn connect_proxy(uri: Uri) -> Result<Arc<dyn Connector>, ProxyUnsupportedError> 
         Some("http" | "https") => Arc::new(connect_http_proxy(uri)),
         Some("socks5") => {
             let host = uri.host().unwrap_or_default();
-            let port = uri.port();
-            let port = port.as_ref();
-            let port = port.map(|p| p.as_str()).unwrap_or("1080");
+            let port = uri.port_u16().unwrap_or(1080);
             Arc::new(connect_socks_proxy(format!("{host}:{port}")))
         }
         _ => return Err(ProxyUnsupportedError(uri)),

--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -558,9 +558,9 @@ impl SessionBuilder {
     /// HTTP or SOCKS5 proxy. This parameter is ignored if you override the connector
     /// with [SessionBuilder::connector].
     ///
-    /// See the [proxy url paramter in the ngrok docs] for additional details.
+    /// See the [proxy url parameter in the ngrok docs] for additional details.
     ///
-    /// [proxy url paramter in the ngrok docs]: https://ngrok.com/docs/ngrok-agent/config#proxy_url
+    /// [proxy url parameter in the ngrok docs]: https://ngrok.com/docs/ngrok-agent/config#proxy_url
     pub fn proxy_url(&mut self, url: Uri) -> Result<&mut Self, ProxyUnsupportedError> {
         self.connector = connect_proxy(url)?;
         Ok(self)


### PR DESCRIPTION
Resolves ngrok-private/ngrok#21250

Adds a `SessionBuilder::proxy_url` method that sets the session up to
connect via either an http or a socks5 proxy. As with `ngrok-go`, these
are mutually-exclusive with the `connector` and will override that
setting.

~~Errors from unsupported proxy schemes, like in `ngrok-go`, are deferred
to connect time. This isn't great, but we're kinda stuck with it since
builder method errors will consume the builder without hope of graceful
recovery, which is *also* bad. Might be time to re-evaluate #95.~~

Rebased this on #107, so we get config-time errors for unsupported proxies :tada: 
