### PR TITLE
ngrok: switch to mutable builder pattern

### DIFF
--- a/cargo-doc-ngrok/Cargo.toml
+++ b/cargo-doc-ngrok/Cargo.toml
@@ -15,6 +15,6 @@ futures = "0.3.25"
 http = "0.2.8"
 hyper = { version = "0.14.23", features = ["server"] }
 hyper-staticfile = "0.9.2"
-ngrok = { path = "../ngrok", version = "0.13", features = ["hyper"] }
+ngrok = { path = "../ngrok", version = "0.14.0-pre.1", features = ["hyper"] }
 tokio = { version = "1.23.0", features = ["full"] }
 watchexec = "2.3.0"

--- a/cargo-doc-ngrok/src/main.rs
+++ b/cargo-doc-ngrok/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let mut tunnel_cfg = sess.http_endpoint();
     if let Some(domain) = args.domain {
-        tunnel_cfg = tunnel_cfg.domain(domain);
+        tunnel_cfg.domain(domain);
     }
 
     let tunnel = tunnel_cfg.listen().await?;

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -29,6 +29,7 @@ parking_lot = "0.12.1"
 once_cell = "1.17.1"
 hostname = "0.3.1"
 regex = "1.7.3"
+http = "0.2.9"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.45.0", features = ["Win32_Foundation"] }

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngrok"
-version = "0.13.1"
+version = "0.14.0-pre.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The ngrok agent SDK"

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Borrow,
     collections::HashMap,
     str::FromStr,
 };
@@ -171,38 +172,38 @@ impl_builder! {
 
 impl HttpTunnelBuilder {
     /// Add the provided CIDR to the allowlist.
-    pub fn allow_cidr(mut self, cidr: impl Into<String>) -> Self {
+    pub fn allow_cidr(&mut self, cidr: impl Into<String>) -> &mut Self {
         self.options.common_opts.cidr_restrictions.allow(cidr);
         self
     }
     /// Add the provided CIDR to the denylist.
-    pub fn deny_cidr(mut self, cidr: impl Into<String>) -> Self {
+    pub fn deny_cidr(&mut self, cidr: impl Into<String>) -> &mut Self {
         self.options.common_opts.cidr_restrictions.deny(cidr);
         self
     }
     /// Sets the PROXY protocol version for connections over this tunnel.
-    pub fn proxy_proto(mut self, proxy_proto: ProxyProto) -> Self {
+    pub fn proxy_proto(&mut self, proxy_proto: ProxyProto) -> &mut Self {
         self.options.common_opts.proxy_proto = proxy_proto;
         self
     }
     /// Sets the opaque metadata string for this tunnel.
-    pub fn metadata(mut self, metadata: impl Into<String>) -> Self {
+    pub fn metadata(&mut self, metadata: impl Into<String>) -> &mut Self {
         self.options.common_opts.metadata = Some(metadata.into());
         self
     }
     /// Sets the ForwardsTo string for this tunnel. This can be viewed via the
     /// API or dashboard.
-    pub fn forwards_to(mut self, forwards_to: impl Into<String>) -> Self {
+    pub fn forwards_to(&mut self, forwards_to: impl Into<String>) -> &mut Self {
         self.options.common_opts.forwards_to = Some(forwards_to.into());
         self
     }
     /// Sets the scheme for this edge.
-    pub fn scheme(mut self, scheme: Scheme) -> Self {
+    pub fn scheme(&mut self, scheme: Scheme) -> &mut Self {
         self.options.scheme = scheme;
         self
     }
     /// Sets the domain to request for this edge.
-    pub fn domain(mut self, domain: impl Into<String>) -> Self {
+    pub fn domain(&mut self, domain: impl Into<String>) -> &mut Self {
         self.options.domain = Some(domain.into());
         self
     }
@@ -210,51 +211,63 @@ impl HttpTunnelBuilder {
     ///
     /// These will be used to authenticate client certificates for requests at
     /// the ngrok edge.
-    pub fn mutual_tlsca(mut self, mutual_tlsca: Bytes) -> Self {
+    pub fn mutual_tlsca(&mut self, mutual_tlsca: Bytes) -> &mut Self {
         self.options.mutual_tlsca.push(mutual_tlsca);
         self
     }
     /// Enables gzip compression.
-    pub fn compression(mut self) -> Self {
+    pub fn compression(&mut self) -> &mut Self {
         self.options.compression = true;
         self
     }
     /// Enables the websocket-to-tcp converter.
-    pub fn websocket_tcp_conversion(mut self) -> Self {
+    pub fn websocket_tcp_conversion(&mut self) -> &mut Self {
         self.options.websocket_tcp_conversion = true;
         self
     }
     /// Sets the 5XX response ratio at which the ngrok edge will stop sending
     /// requests to this tunnel.
-    pub fn circuit_breaker(mut self, circuit_breaker: f64) -> Self {
+    pub fn circuit_breaker(&mut self, circuit_breaker: f64) -> &mut Self {
         self.options.circuit_breaker = circuit_breaker;
         self
     }
 
     /// Adds a header to all requests to this edge.
-    pub fn request_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+    pub fn request_header(
+        &mut self,
+        name: impl Into<String>,
+        value: impl Into<String>,
+    ) -> &mut Self {
         self.options.request_headers.add(name, value);
         self
     }
     /// Adds a header to all responses coming from this edge.
-    pub fn response_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+    pub fn response_header(
+        &mut self,
+        name: impl Into<String>,
+        value: impl Into<String>,
+    ) -> &mut Self {
         self.options.response_headers.add(name, value);
         self
     }
     /// Removes a header from requests to this edge.
-    pub fn remove_request_header(mut self, name: impl Into<String>) -> Self {
+    pub fn remove_request_header(&mut self, name: impl Into<String>) -> &mut Self {
         self.options.request_headers.remove(name);
         self
     }
     /// Removes a header from responses from this edge.
-    pub fn remove_response_header(mut self, name: impl Into<String>) -> Self {
+    pub fn remove_response_header(&mut self, name: impl Into<String>) -> &mut Self {
         self.options.response_headers.remove(name);
         self
     }
 
     /// Adds the provided credentials to the list of basic authentication
     /// credentials.
-    pub fn basic_auth(mut self, username: impl Into<String>, password: impl Into<String>) -> Self {
+    pub fn basic_auth(
+        &mut self,
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> &mut Self {
         self.options
             .basic_auth
             .push((username.into(), password.into()));
@@ -262,23 +275,23 @@ impl HttpTunnelBuilder {
     }
 
     /// Set the OAuth configuraton for this edge.
-    pub fn oauth(mut self, oauth: OauthOptions) -> Self {
-        self.options.oauth = Some(oauth);
+    pub fn oauth(&mut self, oauth: impl Borrow<OauthOptions>) -> &mut Self {
+        self.options.oauth = Some(oauth.borrow().to_owned());
         self
     }
 
     /// Set the OIDC configuration for this edge.
-    pub fn oidc(mut self, oidc: OidcOptions) -> Self {
-        self.options.oidc = Some(oidc);
+    pub fn oidc(&mut self, oidc: impl Borrow<OidcOptions>) -> &mut Self {
+        self.options.oidc = Some(oidc.borrow().to_owned());
         self
     }
 
     /// Configures webhook verification for this edge.
     pub fn webhook_verification(
-        mut self,
+        &mut self,
         provider: impl Into<String>,
         secret: impl Into<String>,
-    ) -> Self {
+    ) -> &mut Self {
         self.options.webhook_verification = Some(WebhookVerification {
             provider: provider.into(),
             secret: secret.into().into(),

--- a/ngrok/src/config/labeled.rs
+++ b/ngrok/src/config/labeled.rs
@@ -58,13 +58,13 @@ impl_builder! {
 impl LabeledTunnelBuilder {
     /// Sets the opaque metadata string for this tunnel.
     /// Viewable via the API.
-    pub fn metadata(mut self, metadata: impl Into<String>) -> Self {
+    pub fn metadata(&mut self, metadata: impl Into<String>) -> &mut Self {
         self.options.common_opts.metadata = Some(metadata.into());
         self
     }
 
     /// Add a label, value pair for this tunnel.
-    pub fn label(mut self, label: impl Into<String>, value: impl Into<String>) -> Self {
+    pub fn label(&mut self, label: impl Into<String>, value: impl Into<String>) -> &mut Self {
         self.options.labels.insert(label.into(), value.into());
         self
     }
@@ -83,7 +83,7 @@ mod test {
         // pass to a function accepting the trait to avoid
         // "creates a temporary which is freed while still in use"
         tunnel_test(
-            LabeledTunnelBuilder {
+            &LabeledTunnelBuilder {
                 session: None,
                 options: Default::default(),
             }
@@ -93,7 +93,7 @@ mod test {
         );
     }
 
-    fn tunnel_test<C>(tunnel_cfg: C)
+    fn tunnel_test<C>(tunnel_cfg: &C)
     where
         C: TunnelConfig,
     {

--- a/ngrok/src/config/oauth.rs
+++ b/ngrok/src/config/oauth.rs
@@ -32,29 +32,29 @@ impl OauthOptions {
     }
 
     /// Provide an OAuth client ID for custom apps.
-    pub fn client_id(mut self, id: impl Into<String>) -> Self {
+    pub fn client_id(&mut self, id: impl Into<String>) -> &mut Self {
         self.client_id = id.into();
         self
     }
 
     /// Provide an OAuth client secret for custom apps.
-    pub fn client_secret(mut self, secret: impl Into<String>) -> Self {
+    pub fn client_secret(&mut self, secret: impl Into<String>) -> &mut Self {
         self.client_secret = SecretString::from(secret.into());
         self
     }
 
     /// Append an email address to the list of allowed emails.
-    pub fn allow_email(mut self, email: impl Into<String>) -> Self {
+    pub fn allow_email(&mut self, email: impl Into<String>) -> &mut Self {
         self.allow_emails.push(email.into());
         self
     }
     /// Append an email domain to the list of allowed domains.
-    pub fn allow_domain(mut self, domain: impl Into<String>) -> Self {
+    pub fn allow_domain(&mut self, domain: impl Into<String>) -> &mut Self {
         self.allow_domains.push(domain.into());
         self
     }
     /// Append a scope to the list of scopes to request.
-    pub fn scope(mut self, scope: impl Into<String>) -> Self {
+    pub fn scope(&mut self, scope: impl Into<String>) -> &mut Self {
         self.scopes.push(scope.into());
         self
     }

--- a/ngrok/src/config/oidc.rs
+++ b/ngrok/src/config/oidc.rs
@@ -30,17 +30,17 @@ impl OidcOptions {
     }
 
     /// Allow the oidc user with the given email to access the tunnel.
-    pub fn allow_email(mut self, email: impl Into<String>) -> Self {
+    pub fn allow_email(&mut self, email: impl Into<String>) -> &mut Self {
         self.allow_emails.push(email.into());
         self
     }
     /// Allow the oidc user with the given email domain to access the tunnel.
-    pub fn allow_domain(mut self, domain: impl Into<String>) -> Self {
+    pub fn allow_domain(&mut self, domain: impl Into<String>) -> &mut Self {
         self.allow_domains.push(domain.into());
         self
     }
     /// Request the given scope from the oidc provider.
-    pub fn scope(mut self, scope: impl Into<String>) -> Self {
+    pub fn scope(&mut self, scope: impl Into<String>) -> &mut Self {
         self.scopes.push(scope.into());
         self
     }

--- a/ngrok/src/config/tcp.rs
+++ b/ngrok/src/config/tcp.rs
@@ -72,33 +72,33 @@ impl_builder! {
 /// The options for a TCP edge.
 impl TcpTunnelBuilder {
     /// Add the provided CIDR to the allowlist.
-    pub fn allow_cidr(mut self, cidr: impl Into<String>) -> Self {
+    pub fn allow_cidr(&mut self, cidr: impl Into<String>) -> &mut Self {
         self.options.common_opts.cidr_restrictions.allow(cidr);
         self
     }
     /// Add the provided CIDR to the denylist.
-    pub fn deny_cidr(mut self, cidr: impl Into<String>) -> Self {
+    pub fn deny_cidr(&mut self, cidr: impl Into<String>) -> &mut Self {
         self.options.common_opts.cidr_restrictions.deny(cidr);
         self
     }
     /// Sets the PROXY protocol version for connections over this tunnel.
-    pub fn proxy_proto(mut self, proxy_proto: ProxyProto) -> Self {
+    pub fn proxy_proto(&mut self, proxy_proto: ProxyProto) -> &mut Self {
         self.options.common_opts.proxy_proto = proxy_proto;
         self
     }
     /// Sets the opaque metadata string for this tunnel.
-    pub fn metadata(mut self, metadata: impl Into<String>) -> Self {
+    pub fn metadata(&mut self, metadata: impl Into<String>) -> &mut Self {
         self.options.common_opts.metadata = Some(metadata.into());
         self
     }
     /// Sets the ForwardsTo string for this tunnel. This can be viewed via the
     /// API or dashboard.
-    pub fn forwards_to(mut self, forwards_to: impl Into<String>) -> Self {
+    pub fn forwards_to(&mut self, forwards_to: impl Into<String>) -> &mut Self {
         self.options.common_opts.forwards_to = Some(forwards_to.into());
         self
     }
     /// Sets the TCP address to request for this edge.
-    pub fn remote_addr(mut self, remote_addr: impl Into<String>) -> Self {
+    pub fn remote_addr(&mut self, remote_addr: impl Into<String>) -> &mut Self {
         self.options.remote_addr = Some(remote_addr.into());
         self
     }
@@ -119,7 +119,7 @@ mod test {
         // pass to a function accepting the trait to avoid
         // "creates a temporary which is freed while still in use"
         tunnel_test(
-            TcpTunnelBuilder {
+            &TcpTunnelBuilder {
                 session: None,
                 options: Default::default(),
             }
@@ -133,7 +133,7 @@ mod test {
         );
     }
 
-    fn tunnel_test<C>(tunnel_cfg: C)
+    fn tunnel_test<C>(tunnel_cfg: &C)
     where
         C: TunnelConfig,
     {

--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -94,33 +94,33 @@ impl_builder! {
 
 impl TlsTunnelBuilder {
     /// Add the provided CIDR to the allowlist.
-    pub fn allow_cidr(mut self, cidr: impl Into<String>) -> Self {
+    pub fn allow_cidr(&mut self, cidr: impl Into<String>) -> &mut Self {
         self.options.common_opts.cidr_restrictions.allow(cidr);
         self
     }
     /// Add the provided CIDR to the denylist.
-    pub fn deny_cidr(mut self, cidr: impl Into<String>) -> Self {
+    pub fn deny_cidr(&mut self, cidr: impl Into<String>) -> &mut Self {
         self.options.common_opts.cidr_restrictions.deny(cidr);
         self
     }
     /// Sets the PROXY protocol version for connections over this tunnel.
-    pub fn proxy_proto(mut self, proxy_proto: ProxyProto) -> Self {
+    pub fn proxy_proto(&mut self, proxy_proto: ProxyProto) -> &mut Self {
         self.options.common_opts.proxy_proto = proxy_proto;
         self
     }
     /// Sets the opaque metadata string for this tunnel.
-    pub fn metadata(mut self, metadata: impl Into<String>) -> Self {
+    pub fn metadata(&mut self, metadata: impl Into<String>) -> &mut Self {
         self.options.common_opts.metadata = Some(metadata.into());
         self
     }
     /// Sets the ForwardsTo string for this tunnel. This can be viewed via the
     /// API or dashboard.
-    pub fn forwards_to(mut self, forwards_to: impl Into<String>) -> Self {
+    pub fn forwards_to(&mut self, forwards_to: impl Into<String>) -> &mut Self {
         self.options.common_opts.forwards_to = Some(forwards_to.into());
         self
     }
     /// Sets the domain to request for this edge.
-    pub fn domain(mut self, domain: impl Into<String>) -> Self {
+    pub fn domain(&mut self, domain: impl Into<String>) -> &mut Self {
         self.options.domain = Some(domain.into());
         self
     }
@@ -129,14 +129,14 @@ impl TlsTunnelBuilder {
     ///
     /// These will be used to authenticate client certificates for requests at
     /// the ngrok edge.
-    pub fn mutual_tlsca(mut self, mutual_tlsca: Bytes) -> Self {
+    pub fn mutual_tlsca(&mut self, mutual_tlsca: Bytes) -> &mut Self {
         self.options.mutual_tlsca.push(mutual_tlsca);
         self
     }
 
     /// Sets the key and certificate in PEM format for TLS termination at the
     /// ngrok edge.
-    pub fn termination(mut self, cert_pem: Bytes, key_pem: Bytes) -> Self {
+    pub fn termination(&mut self, cert_pem: Bytes, key_pem: Bytes) -> &mut Self {
         self.options.key_pem = Some(key_pem);
         self.options.cert_pem = Some(cert_pem);
         self

--- a/ngrok/src/internals/proto.rs
+++ b/ngrok/src/internals/proto.rs
@@ -41,7 +41,7 @@ pub const VERSION: &str = "2";
 
 /// An error that may have an ngrok error code.
 /// All ngrok error codes are documented at https://ngrok.com/docs/errors
-pub trait NgrokError: error::Error {
+pub trait Error: error::Error {
     /// Return the ngrok error code, if one exists for this error.
     fn error_code(&self) -> Option<&str> {
         None
@@ -90,7 +90,7 @@ impl fmt::Display for ErrResp {
     }
 }
 
-impl NgrokError for ErrResp {
+impl Error for ErrResp {
     fn error_code(&self) -> Option<&str> {
         self.error_code.as_deref()
     }

--- a/ngrok/src/internals/raw_session.rs
+++ b/ngrok/src/internals/raw_session.rs
@@ -58,7 +58,7 @@ use super::{
         BindResp,
         CommandResp,
         ErrResp,
-        NgrokError,
+        Error,
         ProxyHeader,
         ReadHeaderError,
         Restart,
@@ -101,7 +101,7 @@ pub enum RpcError {
     Response(ErrResp),
 }
 
-impl NgrokError for RpcError {
+impl Error for RpcError {
     fn error_code(&self) -> Option<&str> {
         match self {
             RpcError::Response(resp) => resp.error_code(),

--- a/ngrok/src/lib.rs
+++ b/ngrok/src/lib.rs
@@ -11,10 +11,6 @@ mod internals {
 
 /// Tunnel and endpoint configuration types.
 pub mod config {
-    // TODO: remove this once all of the config structs are fully fleshed out
-    //       and tested.
-    #![allow(dead_code)]
-
     #[macro_use]
     mod common;
     pub use common::*;
@@ -43,6 +39,8 @@ pub mod tunnel;
 mod tunnel_ext;
 
 #[doc(inline)]
+pub use internals::proto::Error;
+#[doc(inline)]
 pub use session::Session;
 #[doc(inline)]
 pub use tunnel::{
@@ -55,7 +53,7 @@ pub mod prelude {
     #[doc(inline)]
     pub use crate::{
         config::TunnelBuilder,
-        internals::proto::NgrokError,
+        internals::proto::Error,
         tunnel::{
             LabelsTunnel,
             ProtoTunnel,

--- a/ngrok/src/lib.rs
+++ b/ngrok/src/lib.rs
@@ -17,7 +17,7 @@ pub mod config {
 
     mod headers;
     mod http;
-    pub use http::*;
+    pub use self::http::*;
     mod labeled;
     pub use labeled::*;
     mod oauth;

--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -88,7 +88,7 @@ use crate::{
             AuthExtra,
             BindExtra,
             BindOpts,
-            NgrokError,
+            Error,
             SecretString,
         },
         raw_session::{
@@ -293,7 +293,7 @@ pub enum ConnectError {
     Canceled,
 }
 
-impl NgrokError for ConnectError {
+impl Error for ConnectError {
     fn error_code(&self) -> Option<&str> {
         match self {
             ConnectError::Auth(resp) | ConnectError::Rebind(resp) => resp.error_code(),

--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -348,13 +348,13 @@ impl SessionBuilder {
     /// [find your existing authtoken]: https://dashboard.ngrok.com/get-started/your-authtoken
     /// [create a new one]: https://dashboard.ngrok.com/tunnels/authtokens
     /// [authtoken parameter in the ngrok docs]: https://ngrok.com/docs/ngrok-agent/config#authtoken
-    pub fn authtoken(mut self, authtoken: impl Into<String>) -> Self {
+    pub fn authtoken(&mut self, authtoken: impl Into<String>) -> &mut Self {
         self.authtoken = Some(authtoken.into().into());
         self
     }
     /// Shortcut for calling [SessionBuilder::authtoken] with the value of the
     /// NGROK_AUTHTOKEN environment variable.
-    pub fn authtoken_from_env(mut self) -> Self {
+    pub fn authtoken_from_env(&mut self) -> &mut Self {
         self.authtoken = env::var("NGROK_AUTHTOKEN").ok().map(From::from);
         self
     }
@@ -366,7 +366,7 @@ impl SessionBuilder {
     /// details.
     ///
     /// [heartbeat_interval parameter in the ngrok docs]: https://ngrok.com/docs/ngrok-agent/config#heartbeat_interval
-    pub fn heartbeat_interval(mut self, heartbeat_interval: Duration) -> Self {
+    pub fn heartbeat_interval(&mut self, heartbeat_interval: Duration) -> &mut Self {
         self.heartbeat_interval = Some(heartbeat_interval);
         self
     }
@@ -378,7 +378,7 @@ impl SessionBuilder {
     /// details.
     ///
     /// [heartbeat_tolerance parameter in the ngrok docs]: https://ngrok.com/docs/ngrok-agent/config#heartbeat_tolerance
-    pub fn heartbeat_tolerance(mut self, heartbeat_tolerance: Duration) -> Self {
+    pub fn heartbeat_tolerance(&mut self, heartbeat_tolerance: Duration) -> &mut Self {
         self.heartbeat_tolerance = Some(heartbeat_tolerance);
         self
     }
@@ -391,7 +391,7 @@ impl SessionBuilder {
     /// See the [metdata parameter in the ngrok docs] for additional details.
     ///
     /// [metdata parameter in the ngrok docs]: https://ngrok.com/docs/ngrok-agent/config#metadata
-    pub fn metadata(mut self, metadata: impl Into<String>) -> Self {
+    pub fn metadata(&mut self, metadata: impl Into<String>) -> &mut Self {
         self.metadata = Some(metadata.into());
         self
     }
@@ -402,7 +402,7 @@ impl SessionBuilder {
     /// See the [server_addr parameter in the ngrok docs] for additional details.
     ///
     /// [server_addr parameter in the ngrok docs]: https://ngrok.com/docs/ngrok-agent/config#server_addr
-    pub fn server_addr(mut self, addr: impl Into<String>) -> Self {
+    pub fn server_addr(&mut self, addr: impl Into<String>) -> &mut Self {
         self.server_addr = addr.into();
         self
     }
@@ -414,7 +414,7 @@ impl SessionBuilder {
     /// [root_cas parameter in the ngrok docs]
     ///
     /// [root_cas parameter in the ngrok docs]: https://ngrok.com/docs/ngrok-agent/config#root_cas
-    pub fn ca_cert(mut self, ca_cert: Bytes) -> Self {
+    pub fn ca_cert(&mut self, ca_cert: Bytes) -> &mut Self {
         self.ca_cert = Some(ca_cert);
         self
     }
@@ -428,7 +428,7 @@ impl SessionBuilder {
     /// for deeper TLS configuration.
     ///
     /// [root_cas parameter in the ngrok docs]: https://ngrok.com/docs/ngrok-agent/config#root_cas
-    pub fn tls_config(mut self, config: rustls::ClientConfig) -> Self {
+    pub fn tls_config(&mut self, config: rustls::ClientConfig) -> &mut Self {
         self.tls_config = Some(config);
         self
     }
@@ -437,7 +437,7 @@ impl SessionBuilder {
     /// ngrok service. Use this option if you need to connect through an outbound
     /// proxy. In the event of network disruptions, it will be called each time
     /// the session reconnects.
-    pub fn connector(mut self, connect: impl Connector) -> Self {
+    pub fn connector(&mut self, connect: impl Connector) -> &mut Self {
         self.connector = Arc::new(connect);
         self
     }
@@ -452,7 +452,7 @@ impl SessionBuilder {
     /// Do not block inside this callback. It will cause the Dashboard or API
     /// stop operation to time out. Do not call [std::process::exit] inside this
     /// callback, it will also cause the operation to time out.
-    pub fn handle_stop_command(mut self, handler: impl CommandHandler<Stop>) -> Self {
+    pub fn handle_stop_command(&mut self, handler: impl CommandHandler<Stop>) -> &mut Self {
         self.handlers.on_stop = Some(Arc::new(handler));
         self
     }
@@ -468,7 +468,7 @@ impl SessionBuilder {
     /// Do not block inside this callback. It will cause the Dashboard or API
     /// stop operation to time out. Do not call [std::process::exit] inside this
     /// callback, it will also cause the operation to time out.
-    pub fn handle_restart_command(mut self, handler: impl CommandHandler<Restart>) -> Self {
+    pub fn handle_restart_command(&mut self, handler: impl CommandHandler<Restart>) -> &mut Self {
         self.handlers.on_restart = Some(Arc::new(handler));
         self
     }
@@ -484,7 +484,7 @@ impl SessionBuilder {
     /// Do not block inside this callback. It will cause the Dashboard or API
     /// stop operation to time out. Do not call [std::process::exit] inside this
     /// callback, it will also cause the operation to time out.
-    pub fn handle_update_command(mut self, handler: impl CommandHandler<Update>) -> Self {
+    pub fn handle_update_command(&mut self, handler: impl CommandHandler<Update>) -> &mut Self {
         self.handlers.on_update = Some(Arc::new(handler));
         self
     }
@@ -493,7 +493,7 @@ impl SessionBuilder {
     ///
     /// If the handler returns an error, the heartbeat task will exit, resulting
     /// in the session eventually dying as well.
-    pub fn handle_heartbeat(mut self, callback: impl HeartbeatHandler) -> Self {
+    pub fn handle_heartbeat(&mut self, callback: impl HeartbeatHandler) -> &mut Self {
         self.heartbeat_handler = Some(Arc::new(callback));
         self
     }
@@ -508,11 +508,11 @@ impl SessionBuilder {
     ///
     /// [RFC 7230]: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6
     pub fn client_info(
-        mut self,
+        &mut self,
         client_type: impl Into<String>,
         version: impl Into<String>,
         comments: Option<impl Into<String>>,
-    ) -> Self {
+    ) -> &mut Self {
         self.versions.push_front((
             client_type.into(),
             version.into(),


### PR DESCRIPTION
Resolves #95

This also opens the way to allow builder methods to return `Results`, as
the builder won't be consumed in the event of bad input. Then, we can
push some validation to build time rather than connect time.

Combining this with a few other breaking changes, namely:
* No more `Error` stutter
* Validate the server addr at config time
* Validate the heartbeat config at config time
* Remove the server addr/heartbeat errors from the connect error enum
* Split the server addr into host/port when passing them to the connector
