### PR TITLE
Switch to forwarding based on URL and add TLS forwarding

### DIFF
--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngrok"
-version = "0.14.0-pre.2"
+version = "0.14.0-pre.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The ngrok agent SDK"

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -32,6 +32,7 @@ regex = "1.7.3"
 tokio-socks = "0.5.1"
 hyper-proxy = "0.9.1"
 url = "2.4.0"
+rustls-native-certs = "0.6.3"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.45.0", features = ["Win32_Foundation"] }

--- a/ngrok/src/tunnel.rs
+++ b/ngrok/src/tunnel.rs
@@ -102,6 +102,8 @@ macro_rules! tunnel_trait {
             fn forwards_to(&self) -> &str;
             /// Returns the arbitrary metadata string for this tunnel.
             fn metadata(&self) -> &str;
+            /// Returns the protocol for this tunnel.
+            fn proto(&self) -> &str;
             /// Close the tunnel.
             ///
             /// This is an RPC call that must be `.await`ed.
@@ -285,6 +287,10 @@ macro_rules! make_tunnel_type {
 
             fn metadata(&self) -> &str {
                 self.inner.metadata()
+            }
+
+            fn proto(&self) -> &str {
+                self.inner.proto()
             }
         }
 


### PR DESCRIPTION
Switches us from the explicit tcp, http, and pipe forwarding methods to
accepting a URL. This should make it easier for us to update what
protocols we support without having to change the public API.

Eventually, we'll also be able to forward smarter with regards to tls,
proxyproto, etc. like the agent, but that'll come later.
