### PR TITLE
Forward proxy-protocol correctly to tls backends

### DIFF
--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngrok"
-version = "0.14.0-pre.6"
+version = "0.14.0-pre.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The ngrok agent SDK"

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -34,6 +34,7 @@ hyper-proxy = { version = "0.9.1", default-features = false, features = ["rustls
 url = "2.4.0"
 rustls-native-certs = "0.6.3"
 proxy-protocol = "0.5.0"
+pin-project = "1.1.3"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.45.0", features = ["Win32_Foundation"] }

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -33,6 +33,7 @@ tokio-socks = "0.5.1"
 hyper-proxy = { version = "0.9.1", default-features = false, features = ["rustls"] }
 url = "2.4.0"
 rustls-native-certs = "0.6.3"
+proxy-protocol = "0.5.0"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.45.0", features = ["Win32_Foundation"] }

--- a/ngrok/src/conn.rs
+++ b/ngrok/src/conn.rs
@@ -16,9 +16,12 @@ use tokio::io::{
     AsyncWrite,
 };
 
-use crate::internals::proto::{
-    EdgeType,
-    ProxyHeader,
+use crate::{
+    config::ProxyProto,
+    internals::proto::{
+        EdgeType,
+        ProxyHeader,
+    },
 };
 /// A connection from an ngrok tunnel.
 ///
@@ -33,6 +36,7 @@ pub(crate) struct ConnInner {
 pub(crate) struct Info {
     pub(crate) header: ProxyHeader,
     pub(crate) remote_addr: SocketAddr,
+    pub(crate) proxy_proto: ProxyProto,
 }
 
 impl ConnInfo for Info {

--- a/ngrok/src/internals/proto.rs
+++ b/ngrok/src/internals/proto.rs
@@ -772,11 +772,11 @@ pub struct TlsEndpoint {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct TlsTermination {
-    #[serde(with = "base64bytes", skip_serializing_if = "is_default")]
+    #[serde(default, with = "base64bytes", skip_serializing_if = "is_default")]
     pub cert: Vec<u8>,
     #[serde(skip_serializing_if = "is_default", default)]
     pub key: SecretBytes,
-    #[serde(with = "base64bytes", skip_serializing_if = "is_default")]
+    #[serde(default, with = "base64bytes", skip_serializing_if = "is_default")]
     pub sealed_key: Vec<u8>,
 }
 

--- a/ngrok/src/internals/proto.rs
+++ b/ngrok/src/internals/proto.rs
@@ -505,7 +505,7 @@ rpc_req!(SrvInfo, SrvInfoResp, SRV_INFO_REQ);
 /// to use with this tunnel.
 ///
 /// [ProxyProto::None] disables PROXY protocol support.
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
 pub enum ProxyProto {
     /// No PROXY protocol
     #[default]

--- a/ngrok/src/lib.rs
+++ b/ngrok/src/lib.rs
@@ -31,6 +31,8 @@ pub mod config {
     mod webhook_verification;
 }
 
+mod proxy_proto;
+
 /// Types for working with the ngrok session.
 pub mod session;
 /// Types for working with ngrok tunnels.

--- a/ngrok/src/proxy_proto.rs
+++ b/ngrok/src/proxy_proto.rs
@@ -173,7 +173,9 @@ impl WriteState {
                         Poll::Pending | Poll::Ready(Err(_)) => {
                             *self = WriteState::Writing(buf);
                             ready!(write_res)?;
-                            return Ok(()).into();
+                            unreachable!(
+                                "ready! will return for us on either Pending or Ready(Err)"
+                            );
                         }
                         Poll::Ready(Ok(written)) => {
                             buf.advance(written);

--- a/ngrok/src/proxy_proto.rs
+++ b/ngrok/src/proxy_proto.rs
@@ -1,0 +1,435 @@
+use std::{
+    io,
+    mem,
+    pin::{
+        pin,
+        Pin,
+    },
+    task::{
+        ready,
+        Context,
+        Poll,
+    },
+};
+
+use bytes::{
+    Buf,
+    BytesMut,
+};
+use proxy_protocol::{
+    ParseError,
+    ProxyHeader,
+};
+use tokio::io::{
+    AsyncRead,
+    AsyncWrite,
+    ReadBuf,
+};
+use tracing::instrument;
+
+// 536 is the smallest possible TCP segment, which both v1 and v2 are guaranteed
+// to fit into.
+const MAX_HEADER_LEN: usize = 536;
+
+#[derive(Debug)]
+enum ReadState {
+    Reading(Option<ParseError>, BytesMut),
+    Error(proxy_protocol::ParseError, BytesMut),
+    Header(Option<proxy_protocol::ProxyHeader>, BytesMut),
+    None,
+}
+
+impl ReadState {
+    fn new() -> ReadState {
+        ReadState::Reading(None, BytesMut::with_capacity(MAX_HEADER_LEN))
+    }
+
+    fn header(&self) -> Result<Option<&ProxyHeader>, &ParseError> {
+        match self {
+            ReadState::Error(err, _) | ReadState::Reading(Some(err), _) => Err(err),
+            ReadState::None | ReadState::Reading(None, _) => Ok(None),
+            ReadState::Header(hdr, _) => Ok(hdr.as_ref()),
+        }
+    }
+
+    #[instrument(level = "trace", skip(reader))]
+    fn poll_read_header(
+        &mut self,
+        cx: &mut Context,
+        mut reader: Pin<&mut impl AsyncRead>,
+    ) -> Poll<io::Result<()>> {
+        loop {
+            let read_state = mem::replace(self, ReadState::None);
+            let (last_err, mut hdr_buf) = match read_state {
+                // End states
+                ReadState::None | ReadState::Header(_, _) | ReadState::Error(_, _) => {
+                    *self = read_state;
+                    return Poll::Ready(Ok(()));
+                }
+                ReadState::Reading(err, hdr_buf) => (err, hdr_buf),
+            };
+
+            if hdr_buf.len() < MAX_HEADER_LEN {
+                let mut tmp_buf = ReadBuf::uninit(hdr_buf.spare_capacity_mut());
+                let read_res = reader.as_mut().poll_read(cx, &mut tmp_buf);
+                // Regardless of error, make sure we track the read bytes
+                let filled = tmp_buf.filled().len();
+                if filled > 0 {
+                    let len = hdr_buf.len();
+                    // Safety: the tmp_buf is backed by the uninitialized
+                    // portion of hdr_buf. Advancing the len to len + filled is
+                    // guaranteed to only cover the bytes initialized by the
+                    // read.
+                    unsafe { hdr_buf.set_len(len + filled) }
+                }
+                match read_res {
+                    // If we hit the end of the stream due to either an EOF or
+                    // an error, set the state to a terminal one and return the
+                    // result.
+                    Poll::Ready(ref res) if res.is_err() || filled == 0 => {
+                        *self = match last_err {
+                            Some(err) => ReadState::Error(err, hdr_buf),
+                            None => ReadState::Header(None, hdr_buf),
+                        };
+                        return read_res;
+                    }
+                    // Pending leaves the last error and buffer unchanged.
+                    Poll::Pending => {
+                        *self = ReadState::Reading(last_err, hdr_buf);
+                        return read_res;
+                    }
+                    _ => {}
+                }
+            }
+
+            // Create a view into the header buffer so that failed parse
+            // attempts don't consume it.
+            let mut hdr_view = &*hdr_buf;
+
+            match proxy_protocol::parse(&mut hdr_view) {
+                Ok(hdr) => {
+                    hdr_buf.advance(hdr_buf.len() - hdr_view.len());
+                    *self = ReadState::Header(Some(hdr), hdr_buf);
+                    return Poll::Ready(Ok(()));
+                }
+                Err(ParseError::NotProxyHeader) => {
+                    *self = ReadState::Header(None, hdr_buf);
+                    return Poll::Ready(Ok(()));
+                }
+
+                // Keep track of the last error - it might not be fatal if we
+                // simply haven't read enough
+                Err(err) => {
+                    // If we've read too much, consider the error fatal.
+                    if hdr_buf.len() >= MAX_HEADER_LEN {
+                        *self = ReadState::Error(err, hdr_buf);
+                    } else {
+                        *self = ReadState::Reading(Some(err), hdr_buf);
+                    }
+                    continue;
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum WriteState {
+    Writing(BytesMut),
+    None,
+}
+
+impl WriteState {
+    fn new(hdr: proxy_protocol::ProxyHeader) -> Result<WriteState, proxy_protocol::EncodeError> {
+        proxy_protocol::encode(hdr).map(WriteState::Writing)
+    }
+
+    #[instrument(level = "trace", skip(writer))]
+    fn poll_write_header(
+        &mut self,
+        cx: &mut Context,
+        mut writer: Pin<&mut impl AsyncWrite>,
+    ) -> Poll<io::Result<()>> {
+        loop {
+            let state = mem::replace(self, WriteState::None);
+            match state {
+                WriteState::None => return Poll::Ready(Ok(())),
+                WriteState::Writing(mut buf) => {
+                    let write_res = writer.as_mut().poll_write(cx, &buf);
+                    match write_res {
+                        Poll::Pending | Poll::Ready(Err(_)) => {
+                            *self = WriteState::Writing(buf);
+                            ready!(write_res)?;
+                            return Ok(()).into();
+                        }
+                        Poll::Ready(Ok(written)) => {
+                            buf.advance(written);
+                            if !buf.is_empty() {
+                                *self = WriteState::Writing(buf);
+                                continue;
+                            } else {
+                                return Ok(()).into();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+#[pin_project::pin_project]
+pub struct Stream<S> {
+    read_state: ReadState,
+    write_state: WriteState,
+    #[pin]
+    inner: S,
+}
+
+impl<S> Stream<S> {
+    pub fn outgoing(stream: S, header: ProxyHeader) -> Result<Self, proxy_protocol::EncodeError> {
+        Ok(Stream {
+            inner: stream,
+            write_state: WriteState::new(header)?,
+            read_state: ReadState::None,
+        })
+    }
+
+    pub fn incoming(stream: S) -> Self {
+        Stream {
+            inner: stream,
+            read_state: ReadState::new(),
+            write_state: WriteState::None,
+        }
+    }
+
+    pub fn disabled(stream: S) -> Self {
+        Stream {
+            inner: stream,
+            read_state: ReadState::None,
+            write_state: WriteState::None,
+        }
+    }
+}
+
+impl<S> Stream<S>
+where
+    S: AsyncRead,
+{
+    #[instrument(level = "trace", skip(self), fields(read_state = ?self.read_state))]
+    pub fn poll_proxy_header(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<Result<Option<&ProxyHeader>, &ParseError>>> {
+        let this = self.project();
+
+        ready!(this.read_state.poll_read_header(cx, this.inner))?;
+
+        Ok(this.read_state.header()).into()
+    }
+
+    #[instrument(level = "debug", skip(self))]
+    pub async fn proxy_header(&mut self) -> io::Result<Result<Option<&ProxyHeader>, &ParseError>>
+    where
+        Self: Unpin,
+    {
+        let mut this = Pin::new(self);
+
+        futures::future::poll_fn(|cx| {
+            let this = this.as_mut().project();
+            this.read_state.poll_read_header(cx, this.inner)
+        })
+        .await?;
+
+        Ok(this.get_mut().read_state.header())
+    }
+}
+
+impl<S> AsyncRead for Stream<S>
+where
+    S: AsyncRead,
+{
+    #[instrument(level = "trace", skip(self), fields(read_state = ?self.read_state))]
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let mut this = self.project();
+
+        ready!(this.read_state.poll_read_header(cx, this.inner.as_mut()))?;
+
+        match this.read_state {
+            ReadState::Error(_, remainder) | ReadState::Header(_, remainder) => {
+                if !remainder.is_empty() {
+                    let available = std::cmp::min(remainder.len(), buf.remaining());
+                    buf.put_slice(&remainder.split_to(available));
+                    if buf.remaining() == 0 {
+                        return Poll::Ready(Ok(()));
+                    }
+                }
+            }
+            ReadState::None => {}
+            _ => unreachable!(),
+        }
+
+        this.inner.poll_read(cx, buf)
+    }
+}
+
+impl<S> AsyncWrite for Stream<S>
+where
+    S: AsyncWrite,
+{
+    #[instrument(level = "trace", skip(self), fields(write_state = ?self.write_state))]
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        let mut this = self.project();
+
+        ready!(this.write_state.poll_write_header(cx, this.inner.as_mut()))?;
+
+        this.inner.poll_write(cx, buf)
+    }
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.project().inner.poll_flush(cx)
+    }
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.project().inner.poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use bytes::{
+        BufMut,
+        BytesMut,
+    };
+    use proxy_protocol::ProxyHeader;
+    use tokio::io::{
+        AsyncReadExt,
+        AsyncWriteExt,
+    };
+
+    use super::Stream;
+
+    const INPUT: &str = "PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r\n";
+    const PARTIAL_INPUT: &str = "PROXY TCP4 192.168.0.1";
+    const FINAL_INPUT: &str = " 192.168.0.11 56324 443\r\n";
+
+    // Test attributes of the underlying crate to verify assumptions.
+    #[test]
+    fn test_proxy_protocol() {
+        let mut buf = BytesMut::from(INPUT);
+
+        assert!(proxy_protocol::parse(&mut buf).is_ok());
+
+        buf = BytesMut::from(PARTIAL_INPUT);
+
+        assert!(proxy_protocol::parse(&mut &*buf).is_err());
+
+        buf.put_slice(FINAL_INPUT.as_bytes());
+
+        assert!(proxy_protocol::parse(&mut &*buf).is_ok());
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_header_stream() {
+        let (left, mut right) = tokio::io::duplex(1024);
+
+        let mut proxy_stream = Stream::incoming(left);
+
+        // Chunk our writes to ensure that our reader is resilient across split inputs.
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            right
+                .write_all(PARTIAL_INPUT.as_bytes())
+                .await
+                .expect("write header");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            right
+                .write_all(FINAL_INPUT.as_bytes())
+                .await
+                .expect("write header");
+
+            tokio::time::sleep(Duration::from_millis(50)).await;
+
+            right
+                .write_all(b"Hello, world!")
+                .await
+                .expect("write hello");
+
+            right.shutdown().await.expect("shutdown");
+        });
+
+        let hdr = proxy_stream
+            .proxy_header()
+            .await
+            .expect("read header")
+            .expect("decode header")
+            .expect("header exists");
+
+        assert!(matches!(hdr, ProxyHeader::Version1 { .. }));
+
+        let mut buf = String::new();
+
+        proxy_stream
+            .read_to_string(&mut buf)
+            .await
+            .expect("read rest");
+
+        assert_eq!(buf, "Hello, world!");
+
+        // Get the header again - should be the same.
+        let hdr = proxy_stream
+            .proxy_header()
+            .await
+            .expect("read header")
+            .expect("decode header")
+            .expect("header exists");
+
+        assert!(matches!(hdr, ProxyHeader::Version1 { .. }));
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn test_noheader() {
+        let (left, mut right) = tokio::io::duplex(1024);
+
+        let mut proxy_stream = Stream::incoming(left);
+
+        right
+            .write_all(b"Hello, world!")
+            .await
+            .expect("write stream");
+
+        right.shutdown().await.expect("shutdown");
+        drop(right);
+
+        assert!(proxy_stream
+            .proxy_header()
+            .await
+            .unwrap()
+            .unwrap()
+            .is_none());
+
+        let mut buf = String::new();
+
+        proxy_stream
+            .read_to_string(&mut buf)
+            .await
+            .expect("read stream");
+
+        assert_eq!(buf, "Hello, world!");
+
+        panic!();
+    }
+}

--- a/ngrok/src/proxy_proto.rs
+++ b/ngrok/src/proxy_proto.rs
@@ -429,7 +429,5 @@ mod test {
             .expect("read stream");
 
         assert_eq!(buf, "Hello, world!");
-
-        panic!();
     }
 }


### PR DESCRIPTION
Currently, we ignore proxy protocol settings in our tunnels. This means that,
for tls and https connections that are terminated at the ngrok edge, the
incoming connections look like `ProxyProtoStream(PlainTextStream)`. When we
then terminate tls to the backend/upstream/whatever you want to call it, the
final stream looks like `TlsStream(ProxyProtoStream(PlainTextStream))`, where
it's expected to look like `ProxyProtoStream(TlsStream(PlainTextStream))`,
since proxy-protocol is a lower layer than TLS.

To that end, this change plumbs the proxy-proto setting through to the endpoint
connection object, reads the header out of the stream, and then makes sure to
write that to the upstream _first_ before terminating TLS.
