### PR TITLE
Make sure Ready is returned on proxy_proto remainder polling

### DIFF
--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngrok"
-version = "0.14.0-pre.7"
+version = "0.14.0-pre.8"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The ngrok agent SDK"

--- a/ngrok/src/proxy_proto.rs
+++ b/ngrok/src/proxy_proto.rs
@@ -284,9 +284,8 @@ where
                 if !remainder.is_empty() {
                     let available = std::cmp::min(remainder.len(), buf.remaining());
                     buf.put_slice(&remainder.split_to(available));
-                    if buf.remaining() == 0 {
-                        return Poll::Ready(Ok(()));
-                    }
+                    // Make sure Ready is returned regardless of inner's state
+                    return Poll::Ready(Ok(()));
                 }
             }
             ReadState::None => {}

--- a/ngrok/src/tunnel_ext.rs
+++ b/ngrok/src/tunnel_ext.rs
@@ -29,6 +29,11 @@ use hyper::{
 };
 use once_cell::sync::Lazy;
 use proxy_protocol::ProxyHeader;
+#[cfg(feature = "hyper")]
+use tokio::io::{
+    AsyncRead,
+    AsyncWrite,
+};
 #[cfg(target_os = "windows")]
 use tokio::net::windows::named_pipe::ClientOptions;
 #[cfg(not(target_os = "windows"))]
@@ -36,11 +41,7 @@ use tokio::net::UnixStream;
 #[cfg(target_os = "windows")]
 use tokio::time;
 use tokio::{
-    io::{
-        copy_bidirectional,
-        AsyncRead,
-        AsyncWrite,
-    },
+    io::copy_bidirectional,
     net::TcpStream,
     task::JoinHandle,
 };
@@ -48,8 +49,9 @@ use tokio_util::compat::{
     FuturesAsyncReadCompatExt,
     TokioAsyncReadCompatExt,
 };
+#[cfg(feature = "hyper")]
+use tracing::debug;
 use tracing::{
-    debug,
     field,
     warn,
     Instrument,
@@ -160,6 +162,7 @@ impl ConnExt for EndpointConn {
         tokio::spawn(async move {
             let proxy_proto = self.inner.info.proxy_proto;
             let proto_tls = self.proto() == "tls";
+            #[cfg(feature = "hyper")]
             let proto_http = matches!(self.proto(), "http" | "https");
             let passthrough_tls = self.inner.info.passthrough_tls();
 
@@ -223,6 +226,7 @@ fn tls_config() -> Result<Arc<ClientConfig>, &'static io::Error> {
 // Takes the tunnel and connection to make additional decisions on how to wrap
 // the forwarded connection, i.e. reordering tls termination and proxyproto.
 // Note: this additional wrapping logic currently unimplemented.
+#[allow(clippy::unused_io_amount)]
 async fn connect(
     tunnel_tls: bool,
     proxy_proto_header: Option<ProxyHeader>,
@@ -313,7 +317,7 @@ async fn connect(
         conn = Box::new(
             proxy_proto::Stream::outgoing(conn, header)
                 .expect("re-serializing proxy header should always succeed"),
-        )
+        );
     };
 
     if backend_tls && !tunnel_tls {

--- a/ngrok/src/tunnel_ext.rs
+++ b/ngrok/src/tunnel_ext.rs
@@ -226,7 +226,6 @@ fn tls_config() -> Result<Arc<ClientConfig>, &'static io::Error> {
 // Takes the tunnel and connection to make additional decisions on how to wrap
 // the forwarded connection, i.e. reordering tls termination and proxyproto.
 // Note: this additional wrapping logic currently unimplemented.
-#[allow(clippy::unused_io_amount)]
 async fn connect(
     tunnel_tls: bool,
     proxy_proto_header: Option<ProxyHeader>,
@@ -317,7 +316,7 @@ async fn connect(
         conn = Box::new(
             proxy_proto::Stream::outgoing(conn, header)
                 .expect("re-serializing proxy header should always succeed"),
-        );
+        )
     };
 
     if backend_tls && !tunnel_tls {


### PR DESCRIPTION
If an inbound request is too small, no `poll_write` is issued to the outbound proxy stream by `copy_bidirectional`, so the data is never written to the inner stream. This adds returns `Ready` from remainder copying without condition, which resolves issue in an `ngrok-python` proxy test.