### PR TITLE
ngrok: auto-rewrite the http host header

### DIFF
--- a/ngrok/src/config/common.rs
+++ b/ngrok/src/config/common.rs
@@ -112,8 +112,7 @@ macro_rules! impl_builder {
             impl ForwarderBuilder for $name {
                 async fn listen_and_forward(&self, to_url: Url) -> Result<Forwarder<$tun>, RpcError> {
                     let mut cfg = self.clone();
-                    let url_str: &str = to_url.as_ref();
-                    cfg.forwards_to(url_str);
+                    cfg.for_forwarding_to(&to_url).await;
                     let tunnel = cfg.listen().await?;
                     let info = tunnel.make_info();
                     $crate::forwarder::forward(tunnel, info, to_url)
@@ -223,6 +222,11 @@ impl CommonOpts {
     pub(crate) fn user_agent_filter(&self) -> Option<UserAgentFilter> {
         (!self.user_agent_filter.allow.is_empty() || !self.user_agent_filter.deny.is_empty())
             .then_some(self.user_agent_filter.clone().into())
+    }
+
+    pub(crate) fn for_forwarding_to(&mut self, to_url: &Url) -> &mut Self {
+        self.forwards_to = Some(to_url.as_str().into());
+        self
     }
 }
 

--- a/ngrok/src/config/headers.rs
+++ b/ngrok/src/config/headers.rs
@@ -13,10 +13,10 @@ pub(crate) struct Headers {
 
 impl Headers {
     pub(crate) fn add(&mut self, name: impl Into<String>, value: impl Into<String>) {
-        self.added.insert(name.into(), value.into());
+        self.added.insert(name.into().to_lowercase(), value.into());
     }
     pub(crate) fn remove(&mut self, name: impl Into<String>) {
-        self.removed.push(name.into());
+        self.removed.push(name.into().to_lowercase());
     }
     pub(crate) fn has_entries(&self) -> bool {
         !self.added.is_empty() || !self.removed.is_empty()

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -433,12 +433,12 @@ mod test {
             assert_eq!(0.5f64, endpoint.circuit_breaker.unwrap().error_threshold);
 
             let request_headers = endpoint.request_headers.unwrap();
-            assert_eq!(["X-Req-Yup:true"].to_vec(), request_headers.add);
-            assert_eq!(["X-Req-Nope"].to_vec(), request_headers.remove);
+            assert_eq!(["x-req-yup:true"].to_vec(), request_headers.add);
+            assert_eq!(["x-req-nope"].to_vec(), request_headers.remove);
 
             let response_headers = endpoint.response_headers.unwrap();
-            assert_eq!(["X-Res-Yup:true"].to_vec(), response_headers.add);
-            assert_eq!(["X-Res-Nope"].to_vec(), response_headers.remove);
+            assert_eq!(["x-res-yup:true"].to_vec(), response_headers.add);
+            assert_eq!(["x-res-nope"].to_vec(), response_headers.remove);
 
             let webhook = endpoint.webhook_verification.unwrap();
             assert_eq!("twilio", webhook.provider);

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -9,6 +9,7 @@ use bytes::{
     Bytes,
 };
 use thiserror::Error;
+use url::Url;
 
 use super::common::ProxyProto;
 // These are used for doc comment links.
@@ -313,6 +314,11 @@ impl HttpTunnelBuilder {
     /// Add the provided regex to the denylist.
     pub fn deny_user_agent(&mut self, regex: impl Into<String>) -> &mut Self {
         self.options.common_opts.user_agent_filter.deny(regex);
+        self
+    }
+
+    pub(crate) async fn for_forwarding_to(&mut self, to_url: &Url) -> &mut Self {
+        self.options.common_opts.for_forwarding_to(to_url);
         self
     }
 }

--- a/ngrok/src/config/labeled.rs
+++ b/ngrok/src/config/labeled.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use url::Url;
+
 // These are used for doc comment links.
 #[allow(unused_imports)]
 use crate::config::{
@@ -79,6 +81,11 @@ impl LabeledTunnelBuilder {
     /// to [ForwarderBuilder::listen_and_forward].
     pub fn forwards_to(&mut self, forwards_to: impl Into<String>) -> &mut Self {
         self.options.common_opts.forwards_to = forwards_to.into().into();
+        self
+    }
+
+    pub(crate) async fn for_forwarding_to(&mut self, to_url: &Url) -> &mut Self {
+        self.options.common_opts.for_forwarding_to(to_url);
         self
     }
 }

--- a/ngrok/src/config/tcp.rs
+++ b/ngrok/src/config/tcp.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use url::Url;
+
 use super::common::ProxyProto;
 // These are used for doc comment links.
 #[allow(unused_imports)]
@@ -104,6 +106,11 @@ impl TcpTunnelBuilder {
     /// Sets the TCP address to request for this edge.
     pub fn remote_addr(&mut self, remote_addr: impl Into<String>) -> &mut Self {
         self.options.remote_addr = Some(remote_addr.into());
+        self
+    }
+
+    pub(crate) async fn for_forwarding_to(&mut self, to_url: &Url) -> &mut Self {
+        self.options.common_opts.for_forwarding_to(to_url);
         self
     }
 }

--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -4,6 +4,7 @@ use bytes::{
     self,
     Bytes,
 };
+use url::Url;
 
 use super::common::ProxyProto;
 // These are used for doc comment links.
@@ -144,6 +145,11 @@ impl TlsTunnelBuilder {
     pub fn termination(&mut self, cert_pem: Bytes, key_pem: Bytes) -> &mut Self {
         self.options.key_pem = Some(key_pem);
         self.options.cert_pem = Some(cert_pem);
+        self
+    }
+
+    pub(crate) async fn for_forwarding_to(&mut self, to_url: &Url) -> &mut Self {
+        self.options.common_opts.for_forwarding_to(to_url);
         self
     }
 }


### PR DESCRIPTION
This is now implemented by our request header middleware upstream, but this
adds some convenience and docs to it.

Users can call `http_builder.host_header_rewrite(true);` to have it set
automatically on `listen_and_forward` calls, and it also points out the
`.request_header(...)` approach to setting specific values.

Also canonicalizes (lowercases, really) header keys to make sure we aren't
sending multiple values for the same differently-cased "Host" header.
