### PR TITLE
feat: add app protocol 

### DIFF
--- a/ngrok/examples/axum.rs
+++ b/ngrok/examples/axum.rs
@@ -41,7 +41,6 @@ async fn start_tunnel() -> anyhow::Result<HttpTunnel> {
         .connect()
         .await?
         .http_endpoint()
-        // .app_protocol("http2")
         // .allow_cidr("0.0.0.0/0")
         // .basic_auth("ngrok", "online1line")
         // .circuit_breaker(0.5)

--- a/ngrok/examples/axum.rs
+++ b/ngrok/examples/axum.rs
@@ -41,6 +41,7 @@ async fn start_tunnel() -> anyhow::Result<HttpTunnel> {
         .connect()
         .await?
         .http_endpoint()
+        // .app_protocol("http2")
         // .allow_cidr("0.0.0.0/0")
         // .basic_auth("ngrok", "online1line")
         // .circuit_breaker(0.5)

--- a/ngrok/examples/labeled.rs
+++ b/ngrok/examples/labeled.rs
@@ -41,6 +41,7 @@ async fn start_tunnel() -> anyhow::Result<LabeledTunnel> {
 
     let tun = sess
         .labeled_tunnel()
+        //.app_protocol("http2")
         .label("edge", "edghts_<edge_id>")
         .metadata("example tunnel metadata from rust")
         .listen()

--- a/ngrok/src/config/common.rs
+++ b/ngrok/src/config/common.rs
@@ -1,17 +1,19 @@
 use std::{
     collections::HashMap,
     env,
-    process, str::FromStr,
+    process,
+    str::FromStr,
 };
 
 use async_trait::async_trait;
 use once_cell::sync::OnceCell;
-use thiserror::Error;
-use url::Url;
 use serde::{
     Deserialize,
     Serialize,
 };
+use thiserror::Error;
+use url::Url;
+
 pub use crate::internals::proto::ProxyProto;
 use crate::{
     forwarder::Forwarder,
@@ -253,7 +255,6 @@ pub enum AppProtocol {
     #[serde(rename = "http2")]
     HTTP2,
 }
-
 
 /// Errors that can occur while parsing a string into an `AppProtocol`.
 #[derive(Error, Debug, Clone, Eq, PartialEq)]

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -139,10 +139,7 @@ impl TunnelConfig for HttpOptions {
     }
 
     fn forwards_proto(&self) -> String {
-        self.common_opts
-            .forwards_proto
-            .clone()
-            .unwrap_or_default()
+        self.common_opts.forwards_proto.clone().unwrap_or_default()
     }
 
     fn extra(&self) -> BindExtra {

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -11,7 +11,7 @@ use bytes::{
 use thiserror::Error;
 use url::Url;
 
-use super::common::ProxyProto;
+use super::{common::ProxyProto, AppProtocol};
 // These are used for doc comment links.
 #[allow(unused_imports)]
 use crate::config::{
@@ -137,6 +137,13 @@ impl TunnelConfig for HttpOptions {
             .clone()
             .unwrap_or(default_forwards_to().into())
     }
+
+    fn forwards_proto(&self) -> AppProtocol {
+        self.common_opts
+            .forwards_proto
+            .clone()
+    }
+
     fn extra(&self) -> BindExtra {
         BindExtra {
             token: Default::default(),
@@ -253,11 +260,22 @@ impl HttpTunnelBuilder {
         self.options.common_opts.forwards_to = Some(forwards_to.into());
         self
     }
-    /// Sets the scheme for this edge.
+
+    /// Sets the L7 protocol for this tunnel.
+    pub fn app_protocol(&mut self, app_protocol: impl Into<String>) -> &mut Self {
+        let proto_str = app_protocol.into();
+        if let Ok(proto) = AppProtocol::from_str(&proto_str) {
+            self.options.common_opts.forwards_proto = proto;
+        }
+        self
+    }
+
+    /// Sets the L7 protocol string for this tunnel.
     pub fn scheme(&mut self, scheme: Scheme) -> &mut Self {
         self.options.scheme = scheme;
         self
     }
+
     /// Sets the domain to request for this edge.
     ///
     /// https://ngrok.com/docs/network-edge/domains-and-tcp-addresses/#domains
@@ -422,6 +440,7 @@ mod test {
 
     const METADATA: &str = "testmeta";
     const TEST_FORWARD: &str = "testforward";
+    const TEST_FORWARD_PROTO: AppProtocol = AppProtocol::None;
     const ALLOW_CIDR: &str = "0.0.0.0/0";
     const DENY_CIDR: &str = "10.1.1.1/32";
     const CA_CERT: &[u8] = "test ca cert".as_bytes();
@@ -473,6 +492,7 @@ mod test {
             .webhook_verification("twilio", "asdf")
             .basic_auth("ngrok", "online1line")
             .forwards_to(TEST_FORWARD)
+            .app_protocol("")
             .options,
         );
     }
@@ -482,7 +502,7 @@ mod test {
         C: TunnelConfig,
     {
         assert_eq!(TEST_FORWARD, tunnel_cfg.forwards_to());
-
+        assert_eq!(TEST_FORWARD_PROTO, tunnel_cfg.forwards_proto());
         let extra = tunnel_cfg.extra();
         assert_eq!(String::default(), *extra.token);
         assert_eq!(METADATA, extra.metadata);

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -11,10 +11,7 @@ use bytes::{
 use thiserror::Error;
 use url::Url;
 
-use super::{
-    common::ProxyProto,
-    AppProtocol,
-};
+use super::common::ProxyProto;
 // These are used for doc comment links.
 #[allow(unused_imports)]
 use crate::config::{
@@ -141,8 +138,11 @@ impl TunnelConfig for HttpOptions {
             .unwrap_or(default_forwards_to().into())
     }
 
-    fn forwards_proto(&self) -> AppProtocol {
-        self.common_opts.forwards_proto.clone()
+    fn forwards_proto(&self) -> String {
+        self.common_opts
+            .forwards_proto
+            .clone()
+            .unwrap_or(String::new())
     }
 
     fn extra(&self) -> BindExtra {
@@ -264,14 +264,11 @@ impl HttpTunnelBuilder {
 
     /// Sets the L7 protocol for this tunnel.
     pub fn app_protocol(&mut self, app_protocol: impl Into<String>) -> &mut Self {
-        let proto_str = app_protocol.into();
-        if let Ok(proto) = AppProtocol::from_str(&proto_str) {
-            self.options.common_opts.forwards_proto = proto;
-        }
+        self.options.common_opts.forwards_proto = Some(app_protocol.into());
         self
     }
 
-    /// Sets the L7 protocol string for this tunnel.
+    /// Sets the scheme for this edge.
     pub fn scheme(&mut self, scheme: Scheme) -> &mut Self {
         self.options.scheme = scheme;
         self
@@ -441,7 +438,7 @@ mod test {
 
     const METADATA: &str = "testmeta";
     const TEST_FORWARD: &str = "testforward";
-    const TEST_FORWARD_PROTO: AppProtocol = AppProtocol::None;
+    const TEST_FORWARD_PROTO: &str = "http2";
     const ALLOW_CIDR: &str = "0.0.0.0/0";
     const DENY_CIDR: &str = "10.1.1.1/32";
     const CA_CERT: &[u8] = "test ca cert".as_bytes();
@@ -493,7 +490,7 @@ mod test {
             .webhook_verification("twilio", "asdf")
             .basic_auth("ngrok", "online1line")
             .forwards_to(TEST_FORWARD)
-            .app_protocol("")
+            .app_protocol("http2")
             .options,
         );
     }

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -142,7 +142,7 @@ impl TunnelConfig for HttpOptions {
         self.common_opts
             .forwards_proto
             .clone()
-            .unwrap_or(String::new())
+            .unwrap_or_default()
     }
 
     fn extra(&self) -> BindExtra {

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -11,7 +11,10 @@ use bytes::{
 use thiserror::Error;
 use url::Url;
 
-use super::{common::ProxyProto, AppProtocol};
+use super::{
+    common::ProxyProto,
+    AppProtocol,
+};
 // These are used for doc comment links.
 #[allow(unused_imports)]
 use crate::config::{
@@ -139,9 +142,7 @@ impl TunnelConfig for HttpOptions {
     }
 
     fn forwards_proto(&self) -> AppProtocol {
-        self.common_opts
-            .forwards_proto
-            .clone()
+        self.common_opts.forwards_proto.clone()
     }
 
     fn extra(&self) -> BindExtra {

--- a/ngrok/src/config/labeled.rs
+++ b/ngrok/src/config/labeled.rs
@@ -1,7 +1,11 @@
-use std::{collections::HashMap, str::FromStr};
+use std::{
+    collections::HashMap,
+    str::FromStr,
+};
 
 use url::Url;
 
+use super::AppProtocol;
 // These are used for doc comment links.
 #[allow(unused_imports)]
 use crate::config::{
@@ -22,8 +26,6 @@ use crate::{
     Session,
 };
 
-use super::AppProtocol;
-
 /// Options for labeled tunnels.
 #[derive(Default, Clone)]
 struct LabeledOptions {
@@ -40,11 +42,9 @@ impl TunnelConfig for LabeledOptions {
     }
 
     fn forwards_proto(&self) -> AppProtocol {
-        self.common_opts
-            .forwards_proto
-            .clone()
+        self.common_opts.forwards_proto.clone()
     }
-    
+
     fn extra(&self) -> BindExtra {
         BindExtra {
             token: Default::default(),

--- a/ngrok/src/config/labeled.rs
+++ b/ngrok/src/config/labeled.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
 
 use url::Url;
 
@@ -22,6 +22,8 @@ use crate::{
     Session,
 };
 
+use super::AppProtocol;
+
 /// Options for labeled tunnels.
 #[derive(Default, Clone)]
 struct LabeledOptions {
@@ -36,6 +38,13 @@ impl TunnelConfig for LabeledOptions {
             .clone()
             .unwrap_or(default_forwards_to().into())
     }
+
+    fn forwards_proto(&self) -> AppProtocol {
+        self.common_opts
+            .forwards_proto
+            .clone()
+    }
+    
     fn extra(&self) -> BindExtra {
         BindExtra {
             token: Default::default(),
@@ -87,6 +96,15 @@ impl LabeledTunnelBuilder {
     /// https://ngrok.com/docs/api/resources/tunnels/#tunnel-fields
     pub fn forwards_to(&mut self, forwards_to: impl Into<String>) -> &mut Self {
         self.options.common_opts.forwards_to = forwards_to.into().into();
+        self
+    }
+
+    /// Sets the L7 protocol string for this tunnel.
+    pub fn app_protocol(&mut self, forwards_proto: impl Into<String>) -> &mut Self {
+        let proto_str = forwards_proto.into();
+        if let Ok(proto) = AppProtocol::from_str(&proto_str) {
+            self.options.common_opts.forwards_proto = proto;
+        }
         self
     }
 

--- a/ngrok/src/config/labeled.rs
+++ b/ngrok/src/config/labeled.rs
@@ -1,11 +1,7 @@
-use std::{
-    collections::HashMap,
-    str::FromStr,
-};
+use std::collections::HashMap;
 
 use url::Url;
 
-use super::AppProtocol;
 // These are used for doc comment links.
 #[allow(unused_imports)]
 use crate::config::{
@@ -41,8 +37,11 @@ impl TunnelConfig for LabeledOptions {
             .unwrap_or(default_forwards_to().into())
     }
 
-    fn forwards_proto(&self) -> AppProtocol {
-        self.common_opts.forwards_proto.clone()
+    fn forwards_proto(&self) -> String {
+        self.common_opts
+            .forwards_proto
+            .clone()
+            .unwrap_or(String::new())
     }
 
     fn extra(&self) -> BindExtra {
@@ -100,11 +99,8 @@ impl LabeledTunnelBuilder {
     }
 
     /// Sets the L7 protocol string for this tunnel.
-    pub fn app_protocol(&mut self, forwards_proto: impl Into<String>) -> &mut Self {
-        let proto_str = forwards_proto.into();
-        if let Ok(proto) = AppProtocol::from_str(&proto_str) {
-            self.options.common_opts.forwards_proto = proto;
-        }
+    pub fn app_protocol(&mut self, app_protocol: impl Into<String>) -> &mut Self {
+        self.options.common_opts.forwards_proto = Some(app_protocol.into());
         self
     }
 

--- a/ngrok/src/config/labeled.rs
+++ b/ngrok/src/config/labeled.rs
@@ -38,10 +38,7 @@ impl TunnelConfig for LabeledOptions {
     }
 
     fn forwards_proto(&self) -> String {
-        self.common_opts
-            .forwards_proto
-            .clone()
-            .unwrap_or_default()
+        self.common_opts.forwards_proto.clone().unwrap_or_default()
     }
 
     fn extra(&self) -> BindExtra {

--- a/ngrok/src/config/labeled.rs
+++ b/ngrok/src/config/labeled.rs
@@ -41,7 +41,7 @@ impl TunnelConfig for LabeledOptions {
         self.common_opts
             .forwards_proto
             .clone()
-            .unwrap_or(String::new())
+            .unwrap_or_default()
     }
 
     fn extra(&self) -> BindExtra {

--- a/ngrok/src/config/tcp.rs
+++ b/ngrok/src/config/tcp.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use url::Url;
 
-use super::common::ProxyProto;
+use super::{common::ProxyProto, AppProtocol};
 // These are used for doc comment links.
 #[allow(unused_imports)]
 use crate::config::{
@@ -48,6 +48,12 @@ impl TunnelConfig for TcpOptions {
     fn proto(&self) -> String {
         "tcp".into()
     }
+
+    fn forwards_proto(&self) -> AppProtocol {
+        // not supported
+        AppProtocol::None
+    }
+
     fn opts(&self) -> Option<BindOpts> {
         // fill out all the options, translating to proto here
         let mut tcp_endpoint = proto::TcpEndpoint::default();

--- a/ngrok/src/config/tcp.rs
+++ b/ngrok/src/config/tcp.rs
@@ -2,7 +2,10 @@ use std::collections::HashMap;
 
 use url::Url;
 
-use super::{common::ProxyProto, AppProtocol};
+use super::{
+    common::ProxyProto,
+    AppProtocol,
+};
 // These are used for doc comment links.
 #[allow(unused_imports)]
 use crate::config::{

--- a/ngrok/src/config/tcp.rs
+++ b/ngrok/src/config/tcp.rs
@@ -2,10 +2,7 @@ use std::collections::HashMap;
 
 use url::Url;
 
-use super::{
-    common::ProxyProto,
-    AppProtocol,
-};
+use super::common::ProxyProto;
 // These are used for doc comment links.
 #[allow(unused_imports)]
 use crate::config::{
@@ -52,9 +49,9 @@ impl TunnelConfig for TcpOptions {
         "tcp".into()
     }
 
-    fn forwards_proto(&self) -> AppProtocol {
+    fn forwards_proto(&self) -> String {
         // not supported
-        AppProtocol::None
+        String::new()
     }
 
     fn opts(&self) -> Option<BindOpts> {

--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -6,7 +6,10 @@ use bytes::{
 };
 use url::Url;
 
-use super::{common::ProxyProto, AppProtocol};
+use super::{
+    common::ProxyProto,
+    AppProtocol,
+};
 // These are used for doc comment links.
 #[allow(unused_imports)]
 use crate::config::{
@@ -51,7 +54,7 @@ impl TunnelConfig for TlsOptions {
         // not supported
         AppProtocol::None
     }
-    
+
     fn extra(&self) -> BindExtra {
         BindExtra {
             token: Default::default(),

--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -6,10 +6,7 @@ use bytes::{
 };
 use url::Url;
 
-use super::{
-    common::ProxyProto,
-    AppProtocol,
-};
+use super::common::ProxyProto;
 // These are used for doc comment links.
 #[allow(unused_imports)]
 use crate::config::{
@@ -50,9 +47,9 @@ impl TunnelConfig for TlsOptions {
             .unwrap_or(default_forwards_to().into())
     }
 
-    fn forwards_proto(&self) -> AppProtocol {
+    fn forwards_proto(&self) -> String {
         // not supported
-        AppProtocol::None
+        String::new()
     }
 
     fn extra(&self) -> BindExtra {
@@ -65,6 +62,7 @@ impl TunnelConfig for TlsOptions {
     fn proto(&self) -> String {
         "tls".into()
     }
+
     fn opts(&self) -> Option<BindOpts> {
         // fill out all the options, translating to proto here
         let mut tls_endpoint = proto::TlsEndpoint::default();

--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -6,7 +6,7 @@ use bytes::{
 };
 use url::Url;
 
-use super::common::ProxyProto;
+use super::{common::ProxyProto, AppProtocol};
 // These are used for doc comment links.
 #[allow(unused_imports)]
 use crate::config::{
@@ -46,6 +46,12 @@ impl TunnelConfig for TlsOptions {
             .clone()
             .unwrap_or(default_forwards_to().into())
     }
+
+    fn forwards_proto(&self) -> AppProtocol {
+        // not supported
+        AppProtocol::None
+    }
+    
     fn extra(&self) -> BindExtra {
         BindExtra {
             token: Default::default(),

--- a/ngrok/src/internals/proto.rs
+++ b/ngrok/src/internals/proto.rs
@@ -28,6 +28,8 @@ use tokio::io::{
 };
 use tracing::debug;
 
+use crate::config::AppProtocol;
+
 pub const AUTH_REQ: StreamType = StreamType::clamp(0);
 pub const BIND_REQ: StreamType = StreamType::clamp(1);
 pub const UNBIND_REQ: StreamType = StreamType::clamp(2);
@@ -299,6 +301,7 @@ pub struct Bind<T> {
     pub client_id: String,
     pub proto: String,
     pub forwards_to: String,
+    pub forwards_proto: AppProtocol,
     pub opts: T,
     pub extra: BindExtra,
 }
@@ -347,6 +350,7 @@ rpc_req!(Bind<T>, BindResp<T>, BIND_REQ; T: std::fmt::Debug + Serialize + Deseri
 pub struct StartTunnelWithLabel {
     pub labels: HashMap<String, String>,
     pub forwards_to: String,
+    pub forwards_proto: AppProtocol,
     pub metadata: String,
 }
 

--- a/ngrok/src/internals/proto.rs
+++ b/ngrok/src/internals/proto.rs
@@ -28,8 +28,6 @@ use tokio::io::{
 };
 use tracing::debug;
 
-use crate::config::AppProtocol;
-
 pub const AUTH_REQ: StreamType = StreamType::clamp(0);
 pub const BIND_REQ: StreamType = StreamType::clamp(1);
 pub const UNBIND_REQ: StreamType = StreamType::clamp(2);
@@ -301,7 +299,7 @@ pub struct Bind<T> {
     pub client_id: String,
     pub proto: String,
     pub forwards_to: String,
-    pub forwards_proto: AppProtocol,
+    pub forwards_proto: String,
     pub opts: T,
     pub extra: BindExtra,
 }
@@ -350,7 +348,7 @@ rpc_req!(Bind<T>, BindResp<T>, BIND_REQ; T: std::fmt::Debug + Serialize + Deseri
 pub struct StartTunnelWithLabel {
     pub labels: HashMap<String, String>,
     pub forwards_to: String,
-    pub forwards_proto: AppProtocol,
+    pub forwards_proto: String,
     pub metadata: String,
 }
 

--- a/ngrok/src/internals/raw_session.rs
+++ b/ngrok/src/internals/raw_session.rs
@@ -80,7 +80,7 @@ use super::{
 };
 use crate::{
     tunnel::AcceptError::ListenerClosed,
-    Session,
+    Session, config::AppProtocol,
 };
 
 /// Errors arising from tunneling protocol RPC calls.
@@ -322,6 +322,7 @@ impl RpcClient {
         extra: BindExtra,
         id: impl Into<String> + Debug,
         forwards_to: impl Into<String> + Debug,
+        forwards_proto: AppProtocol,
     ) -> Result<BindResp<BindOpts>, RpcError> {
         // Sorry, this is awful. Serde untagged unions are pretty fraught and
         // hard to debug, so we're using this macro to specialize this call
@@ -339,6 +340,7 @@ impl RpcClient {
                             client_id: id.into(),
                             proto: protocol.into(),
                             forwards_to: forwards_to.into(),
+                            forwards_proto: forwards_proto,
                             opts,
                             extra,
                         };
@@ -364,11 +366,13 @@ impl RpcClient {
         labels: HashMap<String, String>,
         metadata: impl Into<String> + Debug,
         forwards_to: impl Into<String> + Debug,
+        forwards_proto: AppProtocol,
     ) -> Result<StartTunnelWithLabelResp, RpcError> {
         let req = StartTunnelWithLabel {
             labels,
             metadata: metadata.into(),
             forwards_to: forwards_to.into(),
+            forwards_proto: forwards_proto,
         };
 
         self.rpc(req).await

--- a/ngrok/src/internals/raw_session.rs
+++ b/ngrok/src/internals/raw_session.rs
@@ -79,8 +79,9 @@ use super::{
     rpc::RpcRequest,
 };
 use crate::{
+    config::AppProtocol,
     tunnel::AcceptError::ListenerClosed,
-    Session, config::AppProtocol,
+    Session,
 };
 
 /// Errors arising from tunneling protocol RPC calls.
@@ -340,7 +341,7 @@ impl RpcClient {
                             client_id: id.into(),
                             proto: protocol.into(),
                             forwards_to: forwards_to.into(),
-                            forwards_proto: forwards_proto,
+                            forwards_proto,
                             opts,
                             extra,
                         };
@@ -372,7 +373,7 @@ impl RpcClient {
             labels,
             metadata: metadata.into(),
             forwards_to: forwards_to.into(),
-            forwards_proto: forwards_proto,
+            forwards_proto,
         };
 
         self.rpc(req).await

--- a/ngrok/src/internals/raw_session.rs
+++ b/ngrok/src/internals/raw_session.rs
@@ -79,7 +79,6 @@ use super::{
     rpc::RpcRequest,
 };
 use crate::{
-    config::AppProtocol,
     tunnel::AcceptError::ListenerClosed,
     Session,
 };
@@ -323,7 +322,7 @@ impl RpcClient {
         extra: BindExtra,
         id: impl Into<String> + Debug,
         forwards_to: impl Into<String> + Debug,
-        forwards_proto: AppProtocol,
+        forwards_proto: impl Into<String> + Debug,
     ) -> Result<BindResp<BindOpts>, RpcError> {
         // Sorry, this is awful. Serde untagged unions are pretty fraught and
         // hard to debug, so we're using this macro to specialize this call
@@ -341,7 +340,7 @@ impl RpcClient {
                             client_id: id.into(),
                             proto: protocol.into(),
                             forwards_to: forwards_to.into(),
-                            forwards_proto,
+                            forwards_proto: forwards_proto.into(),
                             opts,
                             extra,
                         };
@@ -367,13 +366,13 @@ impl RpcClient {
         labels: HashMap<String, String>,
         metadata: impl Into<String> + Debug,
         forwards_to: impl Into<String> + Debug,
-        forwards_proto: AppProtocol,
+        forwards_proto: impl Into<String> + Debug,
     ) -> Result<StartTunnelWithLabelResp, RpcError> {
         let req = StartTunnelWithLabel {
             labels,
             metadata: metadata.into(),
             forwards_to: forwards_to.into(),
-            forwards_proto,
+            forwards_proto: forwards_proto.into(),
         };
 
         self.rpc(req).await

--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -84,12 +84,13 @@ pub use crate::internals::{
 };
 use crate::{
     config::{
+        AppProtocol,
         HttpTunnelBuilder,
         LabeledTunnelBuilder,
         ProxyProto,
         TcpTunnelBuilder,
         TlsTunnelBuilder,
-        TunnelConfig, AppProtocol,
+        TunnelConfig,
     },
     conn::ConnInner,
     internals::{
@@ -701,7 +702,6 @@ impl SessionBuilder {
                 .as_slice(),
         );
 
-        // Todo(del): update config alpn 
         rustls::ClientConfig::builder()
             .with_safe_defaults()
             .with_root_certificates(root_store)
@@ -928,7 +928,12 @@ impl Session {
         } else {
             // labeled tunnel
             let resp = client
-                .listen_label(labels.clone(), &extra.metadata, &forwards_to, forwards_proto.clone())
+                .listen_label(
+                    labels.clone(),
+                    &extra.metadata,
+                    &forwards_to,
+                    forwards_proto.clone(),
+                )
                 .await?;
 
             let info = TunnelInnerInfo {
@@ -1093,7 +1098,12 @@ async fn try_reconnect(
             new_tunnels.insert(id.clone(), tun.clone());
         } else {
             let resp = client
-                .listen_label(tun.labels.clone(), &tun.extra.metadata, &tun.forwards_to, tun.forwards_proto.clone())
+                .listen_label(
+                    tun.labels.clone(),
+                    &tun.extra.metadata,
+                    &tun.forwards_to,
+                    tun.forwards_proto.clone(),
+                )
                 .await
                 .map_err(ConnectError::Rebind)?;
 

--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -84,7 +84,6 @@ pub use crate::internals::{
 };
 use crate::{
     config::{
-        AppProtocol,
         HttpTunnelBuilder,
         LabeledTunnelBuilder,
         ProxyProto,
@@ -132,7 +131,7 @@ struct BoundTunnel {
     extra: BindExtra,
     labels: HashMap<String, String>,
     forwards_to: String,
-    forwards_proto: AppProtocol,
+    forwards_proto: String,
     tx: Sender<Result<ConnInner, AcceptError>>,
 }
 
@@ -884,7 +883,7 @@ impl Session {
         let mut extra = tunnel_cfg.extra();
         let labels = tunnel_cfg.labels();
         let forwards_to = tunnel_cfg.forwards_to();
-        let forwards_proto = tunnel_cfg.forwards_proto().clone();
+        let forwards_proto = tunnel_cfg.forwards_proto();
 
         // non-labeled tunnel
         let (tunnel, bound) = if tunnel_cfg.proto() != "" {
@@ -895,7 +894,7 @@ impl Session {
                     extra.clone(),
                     "",
                     &forwards_to,
-                    forwards_proto.clone(),
+                    &forwards_proto,
                 )
                 .await?;
 
@@ -932,7 +931,7 @@ impl Session {
                     labels.clone(),
                     &extra.metadata,
                     &forwards_to,
-                    forwards_proto.clone(),
+                    &forwards_proto,
                 )
                 .await?;
 
@@ -1090,7 +1089,7 @@ async fn try_reconnect(
                     tun.extra.clone(),
                     id,
                     &tun.forwards_to,
-                    tun.forwards_proto.clone(),
+                    &tun.forwards_proto,
                 )
                 .await
                 .map_err(ConnectError::Rebind)?;
@@ -1102,7 +1101,7 @@ async fn try_reconnect(
                     tun.labels.clone(),
                     &tun.extra.metadata,
                     &tun.forwards_to,
-                    tun.forwards_proto.clone(),
+                    &tun.forwards_proto,
                 )
                 .await
                 .map_err(ConnectError::Rebind)?;

--- a/ngrok/src/tunnel.rs
+++ b/ngrok/src/tunnel.rs
@@ -117,6 +117,7 @@ macro_rules! tunnel_trait {
             /// [TcpTunnelBuilder::forwards_to], etc. to set this value
             /// explicitly.
             fn forwards_to(&self) -> &str;
+
             /// Returns the arbitrary metadata string for this tunnel.
             fn metadata(&self) -> &str;
         }


### PR DESCRIPTION
## Why

We'd like to be able specify http2 when building an http tunnel

## How

Add `app_protocol` to the builder and plumb the `forwards_proto` into the session rpc.

## Validation

Run an example with the http2 app protocol and confirm the correct `forwardsProto` was set to `"http2"` or `""` .