### PR TITLE
ngrok: set the alpn field when app_protocol is specified

### DIFF
--- a/ngrok/src/config/common.rs
+++ b/ngrok/src/config/common.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     env,
+    fmt,
     process,
 };
 

--- a/ngrok/src/config/common.rs
+++ b/ngrok/src/config/common.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::HashMap,
     env,
-    fmt,
     process,
 };
 

--- a/ngrok/src/conn.rs
+++ b/ngrok/src/conn.rs
@@ -37,6 +37,7 @@ pub(crate) struct Info {
     pub(crate) header: ProxyHeader,
     pub(crate) remote_addr: SocketAddr,
     pub(crate) proxy_proto: ProxyProto,
+    pub(crate) app_protocol: Option<String>,
 }
 
 impl ConnInfo for Info {

--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -1030,6 +1030,7 @@ async fn accept_one(
     let guard = inner.tunnels.read().await;
     let res = if let Some(tun) = guard.get(&id) {
         let mut header = conn.header;
+        let app_protocol = Some(tun.forwards_proto.to_string()).filter(|s| !s.is_empty());
         // Note: this is a bit of a hack. Normally, passthrough_tls is only
         // a thing on edge connections, but we're making sure it's set for
         // endpoint connections as well. In their case, we have to look at the
@@ -1050,6 +1051,7 @@ async fn accept_one(
         tun.tx
             .send(Ok(ConnInner {
                 info: crate::conn::Info {
+                    app_protocol,
                     remote_addr,
                     header,
                     proxy_proto,

--- a/ngrok/src/tunnel_ext.rs
+++ b/ngrok/src/tunnel_ext.rs
@@ -228,6 +228,9 @@ fn tls_config(app_protocol: Option<String>) -> Result<Arc<ClientConfig>, &'stati
     // There won't need to be a lot of variation among these, and we'll want to
     // reuse them as much as we can, which is why we initialize them all once
     // and then pull out the one we need.
+    // Disabling the lint because this is a local static that doesn't escape the
+    // enclosing context. It fine.
+    #[allow(clippy::type_complexity)]
     static CONFIGS: Lazy<Result<HashMap<Option<String>, Arc<ClientConfig>>, &'static io::Error>> =
         Lazy::new(|| {
             let root_store = ROOT_STORE.as_ref()?;

--- a/ngrok/src/tunnel_ext.rs
+++ b/ngrok/src/tunnel_ext.rs
@@ -2,14 +2,15 @@
 use std::borrow::Cow;
 #[cfg(target_os = "windows")]
 use std::time::Duration;
+use std::{
+    collections::HashMap,
+    io,
+    sync::Arc,
+};
 #[cfg(feature = "hyper")]
 use std::{
     convert::Infallible,
     fmt,
-};
-use std::{
-    io,
-    sync::Arc,
 };
 
 use async_rustls::rustls::{
@@ -134,6 +135,7 @@ impl ConnExt for EdgeConn {
         tokio::spawn(async move {
             let mut upstream = match connect(
                 self.edge_type() == EdgeType::Tls && self.passthrough_tls(),
+                self.inner.info.app_protocol.clone(),
                 None, // Edges don't support proxyproto (afaik)
                 &url,
             )
@@ -165,6 +167,7 @@ impl ConnExt for EndpointConn {
             #[cfg(feature = "hyper")]
             let proto_http = matches!(self.proto(), "http" | "https");
             let passthrough_tls = self.inner.info.passthrough_tls();
+            let app_protocol = self.inner.info.app_protocol.clone();
 
             let (mut stream, proxy_header) = match proxy_proto {
                 ProxyProto::None => (crate::proxy_proto::Stream::disabled(self), None),
@@ -184,7 +187,13 @@ impl ConnExt for EndpointConn {
                 }
             };
 
-            let mut upstream = match connect(proto_tls && passthrough_tls, proxy_header, &url).await
+            let mut upstream = match connect(
+                proto_tls && passthrough_tls,
+                app_protocol,
+                proxy_header,
+                &url,
+            )
+            .await
             {
                 Ok(conn) => conn,
                 Err(error) => {
@@ -203,8 +212,9 @@ impl ConnExt for EndpointConn {
     }
 }
 
-fn tls_config() -> Result<Arc<ClientConfig>, &'static io::Error> {
-    static CONFIG: Lazy<Result<Arc<ClientConfig>, io::Error>> = Lazy::new(|| {
+fn tls_config(app_protocol: Option<String>) -> Result<Arc<ClientConfig>, &'static io::Error> {
+    // The root certificate store, lazily loaded once.
+    static ROOT_STORE: Lazy<Result<RootCertStore, io::Error>> = Lazy::new(|| {
         let der_certs = rustls_native_certs::load_native_certs()?
             .into_iter()
             .map(|c| c.0)
@@ -212,14 +222,39 @@ fn tls_config() -> Result<Arc<ClientConfig>, &'static io::Error> {
         let der_certs = der_certs.as_slice();
         let mut root_store = RootCertStore::empty();
         root_store.add_parsable_certificates(der_certs);
-        let config = ClientConfig::builder()
-            .with_safe_defaults()
-            .with_root_certificates(root_store)
-            .with_no_client_auth();
-        Ok(Arc::new(config))
+        Ok(root_store)
     });
+    // A hashmap of tls client configs for different configurations.
+    // There won't need to be a lot of variation among these, and we'll want to
+    // reuse them as much as we can, which is why we initialize them all once
+    // and then pull out the one we need.
+    static CONFIGS: Lazy<Result<HashMap<Option<String>, Arc<ClientConfig>>, &'static io::Error>> =
+        Lazy::new(|| {
+            let root_store = ROOT_STORE.as_ref()?;
+            Ok([None, Some("http2".to_string())]
+                .into_iter()
+                .map(|p| {
+                    let mut config = ClientConfig::builder()
+                        .with_safe_defaults()
+                        .with_root_certificates(root_store.clone())
+                        .with_no_client_auth();
+                    if let Some("http2") = p.as_deref() {
+                        config
+                            .alpn_protocols
+                            .extend(["h2", "http/1.1"].iter().map(|s| s.as_bytes().to_vec()));
+                    }
+                    (p, Arc::new(config))
+                })
+                .collect())
+        });
 
-    Ok(CONFIG.as_ref()?.clone())
+    let configs: &HashMap<Option<String>, Arc<ClientConfig>> = CONFIGS.as_ref().map_err(|e| *e)?;
+
+    Ok(configs
+        .get(&app_protocol)
+        .or_else(|| configs.get(&None))
+        .unwrap()
+        .clone())
 }
 
 // Establish the connection to forward the tunnel stream to.
@@ -228,6 +263,7 @@ fn tls_config() -> Result<Arc<ClientConfig>, &'static io::Error> {
 // Note: this additional wrapping logic currently unimplemented.
 async fn connect(
     tunnel_tls: bool,
+    app_protocol: Option<String>,
     proxy_proto_header: Option<ProxyHeader>,
     url: &Url,
 ) -> Result<Box<dyn IoStream>, io::Error> {
@@ -323,7 +359,7 @@ async fn connect(
         let domain = rustls::ServerName::try_from(host)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
         conn = Box::new(
-            async_rustls::TlsConnector::from(tls_config().map_err(|e| e.kind())?)
+            async_rustls::TlsConnector::from(tls_config(app_protocol).map_err(|e| e.kind())?)
                 .connect(domain, conn.compat())
                 .await?
                 .compat(),


### PR DESCRIPTION
If the upstream is a normal HTTPs server, it expects to have http/2 negotiated
via alpn. If alpn isn't provided, it will assume http/1.1. If our edge proxy is
sending down http/2 because `app_protocol` was specified, this results in a
protocol mismatch, and invalid requests/responses will be seen.

This ensures that the negotiation happens as expected.

