### PR TITLE
add root_cas

### DIFF
--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngrok"
-version = "0.14.0-pre.12"
+version = "0.14.0-pre.13"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The ngrok agent SDK"

--- a/ngrok/examples/connect.rs
+++ b/ngrok/examples/connect.rs
@@ -20,6 +20,7 @@ async fn main() -> anyhow::Result<()> {
     let sess = ngrok::Session::builder()
         .authtoken_from_env()
         .metadata("Online in One Line")
+        // .root_cas("trusted")?
         .connect()
         .await?;
 


### PR DESCRIPTION
Allow this on SessionBuilder:

- `.root_cas("trusted")`
- `.root_cas("host")`
- `.root_cas("/path/to/cert")`

Similar to: https://ngrok.com/docs/ngrok-agent/config/#root_cas