### PR TITLE
add rust language server to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
           "rust-src"
           "rustc"
           "rustfmt"
+          "rust-analyzer"
         ];
         fix-n-fmt = pkgs.writeShellScriptBin "fix-n-fmt" ''
           set -euf -o pipefail


### PR DESCRIPTION
### Why 
For nix-based workflow, we often install language servers within the project we are working on. By including the language server here, someone using nix would have all the tooling they need just using the included flake. Additionally, it helps keep the LSP version in sync with the version of rust in the flake.

### Validation
I'm using the Helix text editor to detect the presence of the rust-analyzer LSP. It does this by simply checking that `rust-analyzer` is in the current path.

I also validated that the LSP works by opening one of the example files.

#### Using old flake
<img width="662" alt="image" src="https://github.com/ngrok/ngrok-rust/assets/10949861/0293c903-88a8-4432-ae75-783c247fb29f">


#### Using new flake
<img width="1550" alt="image" src="https://github.com/ngrok/ngrok-rust/assets/10949861/7b1d2d50-d8df-46bd-9767-582e15312c85">
