### PR TITLE
feat: Enable endpoint pooling configuration

### DIFF
--- a/ngrok/CHANGELOG.md
+++ b/ngrok/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.14.0
+- - Adds `pooling_enabled` option, allowing the endpoint to pool with other endpoints with the same host/port/binding
+
 ## 0.13.1
 
 - Preserve the `ERR_NGROK` prefix for error codes.

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ngrok"
-version = "0.14.0-pre.17"
+version = "0.14.0-pre.18"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The ngrok agent SDK"

--- a/ngrok/examples/axum.rs
+++ b/ngrok/examples/axum.rs
@@ -63,6 +63,7 @@ async fn main() -> Result<(), BoxError> {
         //         .scope("<scope>"),
         // )
         // .traffic_policy(POLICY_JSON)
+        // .with_pooling_enabled(false)
         // .proxy_proto(ProxyProto::None)
         // .remove_request_header("X-Req-Nope")
         // .remove_response_header("X-Res-Nope")

--- a/ngrok/examples/axum.rs
+++ b/ngrok/examples/axum.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), BoxError> {
         //         .scope("<scope>"),
         // )
         // .traffic_policy(POLICY_JSON)
-        // .with_pooling_enabled(false)
+        // .pooling_enabled(false)
         // .proxy_proto(ProxyProto::None)
         // .remove_request_header("X-Req-Nope")
         // .remove_response_header("X-Res-Nope")

--- a/ngrok/examples/connect.rs
+++ b/ngrok/examples/connect.rs
@@ -29,6 +29,7 @@ async fn main() -> anyhow::Result<()> {
         // .allow_cidr("0.0.0.0/0")
         // .deny_cidr("10.1.1.1/32")
         // .verify_upstream_tls(false)
+        // .pooling_enabled(false)
         // .forwards_to("example rust"),
         // .proxy_proto(ProxyProto::None)
         // .remote_addr("<n>.tcp.ngrok.io:<p>")

--- a/ngrok/src/config/common.rs
+++ b/ngrok/src/config/common.rs
@@ -211,6 +211,8 @@ pub(crate) struct CommonOpts {
     // Policy that defines rules that should be applied to incoming or outgoing
     // connections to the edge.
     pub(crate) traffic_policy: Option<String>,
+    // Allows the endpoint to pool with other endpoints with the same host/port/binding
+    pub(crate) pooling_enabled: Option<bool>,
 }
 
 impl CommonOpts {

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -1,24 +1,46 @@
-use std::{borrow::Borrow, collections::HashMap, convert::From, str::FromStr};
+use std::{
+    borrow::Borrow,
+    collections::HashMap,
+    convert::From,
+    str::FromStr,
+};
 
 use bytes::Bytes;
 use thiserror::Error;
 use url::Url;
 
-use super::{common::ProxyProto, Policy};
+use super::{
+    common::ProxyProto,
+    Policy,
+};
 // These are used for doc comment links.
 #[allow(unused_imports)]
-use crate::config::{ForwarderBuilder, TunnelBuilder};
+use crate::config::{
+    ForwarderBuilder,
+    TunnelBuilder,
+};
 use crate::{
     config::{
-        common::{default_forwards_to, CommonOpts, TunnelConfig},
+        common::{
+            default_forwards_to,
+            CommonOpts,
+            TunnelConfig,
+        },
         headers::Headers,
         oauth::OauthOptions,
         oidc::OidcOptions,
         webhook_verification::WebhookVerification,
     },
     internals::proto::{
-        BasicAuth, BasicAuthCredential, BindExtra, BindOpts, CircuitBreaker, Compression,
-        HttpEndpoint, UserAgentFilter, WebsocketTcpConverter,
+        BasicAuth,
+        BasicAuthCredential,
+        BindExtra,
+        BindOpts,
+        CircuitBreaker,
+        Compression,
+        HttpEndpoint,
+        UserAgentFilter,
+        WebsocketTcpConverter,
     },
     tunnel::HttpTunnel,
     Session,

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -285,12 +285,6 @@ impl HttpTunnelBuilder {
         self
     }
 
-    /// Allows the endpoint to pool with other endpoints with the same host/port/binding
-    pub fn pooling_enabled(&mut self, pooling_enabled: impl Into<bool>) -> &mut Self {
-       self.options.common_opts.pooling_enabled = Some(pooling_enabled.into());
-        self
-    }
-
     /// Disables backend TLS certificate verification for forwards from this tunnel.
     pub fn verify_upstream_tls(&mut self, verify_upstream_tls: bool) -> &mut Self {
         self.options
@@ -476,6 +470,12 @@ impl HttpTunnelBuilder {
         }
         self
     }
+
+    /// Allows the endpoint to pool with other endpoints with the same host/port/binding
+    pub fn pooling_enabled(&mut self, pooling_enabled: impl Into<bool>) -> &mut Self {
+        self.options.common_opts.pooling_enabled = Some(pooling_enabled.into());
+        self
+     }
 }
 
 #[cfg(test)]

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -196,6 +196,7 @@ impl TunnelConfig for HttpOptions {
             } else {
                 None
             },
+            pooling_enabled: self.common_opts.pooling_enabled,
             ..Default::default()
         };
 
@@ -281,6 +282,12 @@ impl HttpTunnelBuilder {
     /// Sets the L7 protocol for this tunnel.
     pub fn app_protocol(&mut self, app_protocol: impl Into<String>) -> &mut Self {
         self.options.common_opts.forwards_proto = Some(app_protocol.into());
+        self
+    }
+
+    /// Allows the endpoint to pool with other endpoints with the same host/port/binding
+    pub fn pooling_enabled(&mut self, pooling_enabled: impl Into<bool>) -> &mut Self {
+       self.options.common_opts.pooling_enabled = Some(pooling_enabled.into());
         self
     }
 

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -154,6 +154,7 @@ impl TunnelConfig for HttpOptions {
             ip_policy_ref: Default::default(),
             metadata: self.common_opts.metadata.clone().unwrap_or_default(),
             bindings: self.bindings.clone(),
+            pooling_enabled: self.common_opts.pooling_enabled.unwrap_or(false),
         }
     }
     fn proto(&self) -> String {
@@ -196,7 +197,6 @@ impl TunnelConfig for HttpOptions {
             } else {
                 None
             },
-            pooling_enabled: self.common_opts.pooling_enabled,
             ..Default::default()
         };
 

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -1,46 +1,24 @@
-use std::{
-    borrow::Borrow,
-    collections::HashMap,
-    convert::From,
-    str::FromStr,
-};
+use std::{borrow::Borrow, collections::HashMap, convert::From, str::FromStr};
 
 use bytes::Bytes;
 use thiserror::Error;
 use url::Url;
 
-use super::{
-    common::ProxyProto,
-    Policy,
-};
+use super::{common::ProxyProto, Policy};
 // These are used for doc comment links.
 #[allow(unused_imports)]
-use crate::config::{
-    ForwarderBuilder,
-    TunnelBuilder,
-};
+use crate::config::{ForwarderBuilder, TunnelBuilder};
 use crate::{
     config::{
-        common::{
-            default_forwards_to,
-            CommonOpts,
-            TunnelConfig,
-        },
+        common::{default_forwards_to, CommonOpts, TunnelConfig},
         headers::Headers,
         oauth::OauthOptions,
         oidc::OidcOptions,
         webhook_verification::WebhookVerification,
     },
     internals::proto::{
-        BasicAuth,
-        BasicAuthCredential,
-        BindExtra,
-        BindOpts,
-        CircuitBreaker,
-        Compression,
-        HttpEndpoint,
-        UserAgentFilter,
-        WebsocketTcpConverter,
+        BasicAuth, BasicAuthCredential, BindExtra, BindOpts, CircuitBreaker, Compression,
+        HttpEndpoint, UserAgentFilter, WebsocketTcpConverter,
     },
     tunnel::HttpTunnel,
     Session,
@@ -475,7 +453,7 @@ impl HttpTunnelBuilder {
     pub fn pooling_enabled(&mut self, pooling_enabled: impl Into<bool>) -> &mut Self {
         self.options.common_opts.pooling_enabled = Some(pooling_enabled.into());
         self
-     }
+    }
 }
 
 #[cfg(test)]

--- a/ngrok/src/config/labeled.rs
+++ b/ngrok/src/config/labeled.rs
@@ -51,6 +51,7 @@ impl TunnelConfig for LabeledOptions {
             ip_policy_ref: Default::default(),
             metadata: self.common_opts.metadata.clone().unwrap_or_default(),
             bindings: Vec::new(),
+            pooling_enabled: self.common_opts.pooling_enabled.unwrap_or(false),
         }
     }
     fn proto(&self) -> String {

--- a/ngrok/src/config/tcp.rs
+++ b/ngrok/src/config/tcp.rs
@@ -84,7 +84,7 @@ impl TunnelConfig for TcpOptions {
         } else {
             None
         };
-
+        tcp_endpoint.pooling_enabled = self.common_opts.pooling_enabled;
         Some(BindOpts::Tcp(tcp_endpoint))
     }
     fn labels(&self) -> HashMap<String, String> {
@@ -180,6 +180,12 @@ impl TcpTunnelBuilder {
         self.options.common_opts.for_forwarding_to(to_url);
         self
     }
+
+    /// Allows the endpoint to pool with other endpoints with the same host/port/binding
+    pub fn pooling_enabled(&mut self, pooling_enabled: impl Into<bool>) -> &mut Self {
+        self.options.common_opts.pooling_enabled = Some(pooling_enabled.into());
+        self
+     }
 }
 
 #[cfg(test)]

--- a/ngrok/src/config/tcp.rs
+++ b/ngrok/src/config/tcp.rs
@@ -1,14 +1,31 @@
-use std::{collections::HashMap, convert::From};
+use std::{
+    collections::HashMap,
+    convert::From,
+};
 
 use url::Url;
 
-use super::{common::ProxyProto, Policy};
+use super::{
+    common::ProxyProto,
+    Policy,
+};
 // These are used for doc comment links.
 #[allow(unused_imports)]
-use crate::config::{ForwarderBuilder, TunnelBuilder};
+use crate::config::{
+    ForwarderBuilder,
+    TunnelBuilder,
+};
 use crate::{
-    config::common::{default_forwards_to, CommonOpts, TunnelConfig},
-    internals::proto::{self, BindExtra, BindOpts},
+    config::common::{
+        default_forwards_to,
+        CommonOpts,
+        TunnelConfig,
+    },
+    internals::proto::{
+        self,
+        BindExtra,
+        BindOpts,
+    },
     tunnel::TcpTunnel,
     Session,
 };

--- a/ngrok/src/config/tcp.rs
+++ b/ngrok/src/config/tcp.rs
@@ -51,6 +51,7 @@ impl TunnelConfig for TcpOptions {
             ip_policy_ref: Default::default(),
             metadata: self.common_opts.metadata.clone().unwrap_or_default(),
             bindings: self.bindings.clone(),
+            pooling_enabled: self.common_opts.pooling_enabled.unwrap_or(false),
         }
     }
     fn proto(&self) -> String {
@@ -84,7 +85,6 @@ impl TunnelConfig for TcpOptions {
         } else {
             None
         };
-        tcp_endpoint.pooling_enabled = self.common_opts.pooling_enabled;
         Some(BindOpts::Tcp(tcp_endpoint))
     }
     fn labels(&self) -> HashMap<String, String> {

--- a/ngrok/src/config/tcp.rs
+++ b/ngrok/src/config/tcp.rs
@@ -1,31 +1,14 @@
-use std::{
-    collections::HashMap,
-    convert::From,
-};
+use std::{collections::HashMap, convert::From};
 
 use url::Url;
 
-use super::{
-    common::ProxyProto,
-    Policy,
-};
+use super::{common::ProxyProto, Policy};
 // These are used for doc comment links.
 #[allow(unused_imports)]
-use crate::config::{
-    ForwarderBuilder,
-    TunnelBuilder,
-};
+use crate::config::{ForwarderBuilder, TunnelBuilder};
 use crate::{
-    config::common::{
-        default_forwards_to,
-        CommonOpts,
-        TunnelConfig,
-    },
-    internals::proto::{
-        self,
-        BindExtra,
-        BindOpts,
-    },
+    config::common::{default_forwards_to, CommonOpts, TunnelConfig},
+    internals::proto::{self, BindExtra, BindOpts},
     tunnel::TcpTunnel,
     Session,
 };
@@ -185,7 +168,7 @@ impl TcpTunnelBuilder {
     pub fn pooling_enabled(&mut self, pooling_enabled: impl Into<bool>) -> &mut Self {
         self.options.common_opts.pooling_enabled = Some(pooling_enabled.into());
         self
-     }
+    }
 }
 
 #[cfg(test)]

--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -3,13 +3,28 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use url::Url;
 
-use super::{common::ProxyProto, Policy};
+use super::{
+    common::ProxyProto,
+    Policy,
+};
 // These are used for doc comment links.
 #[allow(unused_imports)]
-use crate::config::{ForwarderBuilder, TunnelBuilder};
+use crate::config::{
+    ForwarderBuilder,
+    TunnelBuilder,
+};
 use crate::{
-    config::common::{default_forwards_to, CommonOpts, TunnelConfig},
-    internals::proto::{self, BindExtra, BindOpts, TlsTermination},
+    config::common::{
+        default_forwards_to,
+        CommonOpts,
+        TunnelConfig,
+    },
+    internals::proto::{
+        self,
+        BindExtra,
+        BindOpts,
+        TlsTermination,
+    },
     tunnel::TlsTunnel,
     Session,
 };

--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -63,6 +63,7 @@ impl TunnelConfig for TlsOptions {
             ip_policy_ref: Default::default(),
             metadata: self.common_opts.metadata.clone().unwrap_or_default(),
             bindings: self.bindings.clone(),
+            pooling_enabled: self.common_opts.pooling_enabled.unwrap_or(false),
         }
     }
     fn proto(&self) -> String {
@@ -101,7 +102,6 @@ impl TunnelConfig for TlsOptions {
         } else {
             None
         };
-        tls_endpoint.pooling_enabled = self.common_opts.pooling_enabled;
         Some(BindOpts::Tls(tls_endpoint))
     }
     fn labels(&self) -> HashMap<String, String> {

--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -101,7 +101,7 @@ impl TunnelConfig for TlsOptions {
         } else {
             None
         };
-
+        tls_endpoint.pooling_enabled = self.common_opts.pooling_enabled;
         Some(BindOpts::Tls(tls_endpoint))
     }
     fn labels(&self) -> HashMap<String, String> {
@@ -217,6 +217,12 @@ impl TlsTunnelBuilder {
         self.options.common_opts.for_forwarding_to(to_url);
         self
     }
+
+    /// Allows the endpoint to pool with other endpoints with the same host/port/binding
+    pub fn pooling_enabled(&mut self, pooling_enabled: impl Into<bool>) -> &mut Self {
+        self.options.common_opts.pooling_enabled = Some(pooling_enabled.into());
+         self
+     }
 }
 
 #[cfg(test)]

--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -3,28 +3,13 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use url::Url;
 
-use super::{
-    common::ProxyProto,
-    Policy,
-};
+use super::{common::ProxyProto, Policy};
 // These are used for doc comment links.
 #[allow(unused_imports)]
-use crate::config::{
-    ForwarderBuilder,
-    TunnelBuilder,
-};
+use crate::config::{ForwarderBuilder, TunnelBuilder};
 use crate::{
-    config::common::{
-        default_forwards_to,
-        CommonOpts,
-        TunnelConfig,
-    },
-    internals::proto::{
-        self,
-        BindExtra,
-        BindOpts,
-        TlsTermination,
-    },
+    config::common::{default_forwards_to, CommonOpts, TunnelConfig},
+    internals::proto::{self, BindExtra, BindOpts, TlsTermination},
     tunnel::TlsTunnel,
     Session,
 };
@@ -221,8 +206,8 @@ impl TlsTunnelBuilder {
     /// Allows the endpoint to pool with other endpoints with the same host/port/binding
     pub fn pooling_enabled(&mut self, pooling_enabled: impl Into<bool>) -> &mut Self {
         self.options.common_opts.pooling_enabled = Some(pooling_enabled.into());
-         self
-     }
+        self
+    }
 }
 
 #[cfg(test)]

--- a/ngrok/src/internals/proto.rs
+++ b/ngrok/src/internals/proto.rs
@@ -324,6 +324,8 @@ pub struct BindExtra {
     pub ip_policy_ref: String,
     pub metadata: String,
     pub bindings: Vec<String>,
+    #[serde(rename = "PoolingEnabled")]
+    pub pooling_enabled: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -699,8 +701,6 @@ pub struct HttpEndpoint {
     pub user_agent_filter: Option<UserAgentFilter>,
     #[serde(rename = "TrafficPolicy")]
     pub traffic_policy: Option<PolicyWrapper>,
-    #[serde(rename = "PoolingEnabled")]
-    pub pooling_enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -828,8 +828,6 @@ pub struct TcpEndpoint {
     pub ip_restriction: Option<IpRestriction>,
     #[serde(rename = "TrafficPolicy")]
     pub traffic_policy: Option<PolicyWrapper>,
-    #[serde(rename = "PoolingEnabled")]
-    pub pooling_enabled: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -849,8 +847,6 @@ pub struct TlsEndpoint {
     pub ip_restriction: Option<IpRestriction>,
     #[serde(rename = "TrafficPolicy")]
     pub traffic_policy: Option<PolicyWrapper>,
-    #[serde(rename = "PoolingEnabled")]
-    pub pooling_enabled: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]

--- a/ngrok/src/internals/proto.rs
+++ b/ngrok/src/internals/proto.rs
@@ -699,6 +699,8 @@ pub struct HttpEndpoint {
     pub user_agent_filter: Option<UserAgentFilter>,
     #[serde(rename = "TrafficPolicy")]
     pub traffic_policy: Option<PolicyWrapper>,
+    #[serde(rename = "PoolingEnabled")]
+    pub pooling_enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -826,6 +828,8 @@ pub struct TcpEndpoint {
     pub ip_restriction: Option<IpRestriction>,
     #[serde(rename = "TrafficPolicy")]
     pub traffic_policy: Option<PolicyWrapper>,
+    #[serde(rename = "PoolingEnabled")]
+    pub pooling_enabled: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -845,6 +849,8 @@ pub struct TlsEndpoint {
     pub ip_restriction: Option<IpRestriction>,
     #[serde(rename = "TrafficPolicy")]
     pub traffic_policy: Option<PolicyWrapper>,
+    #[serde(rename = "PoolingEnabled")]
+    pub pooling_enabled: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]


### PR DESCRIPTION
# Take it for a spin in your own project!

1. Clone the repo and checkout this branch
2. Copy/pasta the below code (use the relative path of the ngrok-rust sdk you cloned as the path of the ngrok crate in Cargo.toml)
3. `cargo build`
4. `cargo run`
5. Start a server on whatever two ports you'd like (I use `python -m http.server 3000 && python -m http.server 8000)
6. Open the url of your ngrok reserved domain in the browser
7. Observe that both ports (3000 and 8000) show the http requests!

### main.rs
```rust
#![deny(warnings)]
use axum::{Router, routing::get};
use std::net::SocketAddr;
use url::Url;
use ngrok::config::ForwarderBuilder;

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {  
    // Create Axum app
    let app = Router::new()
        .route("/", get(|| async { "Hello from Axum!" }));

    // Spawn Axum server
    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
    tokio::spawn(async move {
        axum::serve(
            tokio::net::TcpListener::bind(addr).await.unwrap(),
            app
        ).await.unwrap();
    });

    // Set up ngrok tunnel
    let sess1 = ngrok::Session::builder()
        .authtoken_from_env()
        .connect()
        .await?;
    let sess2 = ngrok::Session::builder()
        .authtoken_from_env()
        .connect()
        .await?;

    let _listener = sess1
        .http_endpoint()
        .domain(/* your ngrok reserved domain */)
        .pooling_enabled(true)
        .listen_and_forward(Url::parse("http://localhost:3000").unwrap())
        .await?;
    let _listener2 = sess2
        .http_endpoint()
        .domain(/* your ngrok reserved domain */)
        .pooling_enabled(true)
        .listen_and_forward(Url::parse("http://localhost:8000").unwrap())
        .await?;

    // Wait indefinitely
    tokio::signal::ctrl_c().await?;
    Ok(())
}
```

Cargo.toml
```rust
[package]
name = "ngrok-demo"
version = "0.1.0"
edition = "2021"

[dependencies]
ngrok = {path = "../../ngrok-rust/ngrok"}
tokio = { version = "1", features = [
    "full"
] }
axum = { version = "0.7.4", features = ["tokio"] }
async-trait = "0.1.59"
hyper = {version = "1", features = ["full"]}
hyper-util = { version = "0.1", features = [
	"full"
] }
url = "2.5.4"
```

