### PR TITLE
chore: Remove hyper_proxy crate

### DIFF
--- a/cargo-doc-ngrok/Cargo.toml
+++ b/cargo-doc-ngrok/Cargo.toml
@@ -17,7 +17,7 @@ http = "1.0.0"
 hyper = { version = "1.1.0", features = ["server"] }
 hyper-staticfile = "0.10.0"
 hyper-util = { version = "0.1.3", features = ["server", "tokio", "server-auto", "http1"] }
-ngrok = { path = "../ngrok", version = "0.14.0", features = ["hyper", "axum"] }
+ngrok = { path = "../ngrok", version = "0.15.0", features = ["hyper", "axum"] }
 tokio = { version = "1.23.0", features = ["full"] }
 watchexec = "2.3.0"
 # watchexec-signals 1.0.1 causes a compilation error.

--- a/ngrok/CHANGELOG.md
+++ b/ngrok/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.15.0
+- - Removes `hyper-proxy` and `ring` dependencies 
+
 ## 0.14.0
 - - Adds `pooling_enabled` option, allowing the endpoint to pool with other endpoints with the same host/port/binding
 

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -1,17 +1,40 @@
 [package]
 name = "ngrok"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "The ngrok agent SDK"
 repository = "https://github.com/ngrok/ngrok-rust"
 
 [dependencies]
+arc-swap = "1.5.1"
+async-trait = "0.1.59"
+awaitdrop = "0.1.1"
+axum = { version = "0.7.4", features = ["tokio"], optional = true }
+axum-core = "0.4.3"
+
+base64 = "0.21.7"
+bitflags = "2.4.2"
+bytes = "1.3.0"
+
+futures = "0.3.25"
+futures-rustls = { version = "0.26.0" }
+futures-util = "0.3.30"
+hostname = "0.3.1"
+hyper = { version = "^1.1.0", optional = true }
+hyper-http-proxy = "1.1.0"
+hyper-util = { version = "0.1.3", features = ["tokio"] }
+once_cell = "1.17.1"
 muxado = { path = "../muxado", version = "0.5" }
+pin-project = "1.1.3"
+parking_lot = "0.12.1"
+proxy-protocol = "0.5.0"
+regex = "1.7.3"
+rustls-native-certs = "0.7.0"
+rustls-pemfile = "2.0.0"
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
-base64 = "0.21.7"
 tokio = { version = "1.23.0", features = [
 	"io-util",
 	"net",
@@ -19,60 +42,39 @@ tokio = { version = "1.23.0", features = [
 	"time",
 	"rt",
 ] }
-tracing = "0.1.37"
-futures-rustls = { version = "0.25.1" }
-tokio-util = { version = "0.7.4", features = ["compat"] }
-futures = "0.3.25"
-hyper-0-14 = { package = "hyper", version = "0.14" }
-hyper = { version = "1.1.0", optional = true }
-axum = { version = "0.7.4", features = ["tokio"], optional = true }
-rustls-pemfile = "2.0.0"
-async-trait = "0.1.59"
-bytes = "1.3.0"
-arc-swap = "1.5.1"
 tokio-retry = "0.3.0"
-awaitdrop = "0.1.1"
-parking_lot = "0.12.1"
-once_cell = "1.17.1"
-hostname = "0.3.1"
-regex = "1.7.3"
 tokio-socks = "0.5.1"
-hyper-proxy = { version = "0.9.1", default-features = false, features = [
-	"rustls",
-] }
+tokio-util = { version = "0.7.4", features = ["compat"] }
+tower-service = { version = "0.3.3"}
+tracing = "0.1.37"
 url = "2.4.0"
-rustls-native-certs = "0.7.0"
-proxy-protocol = "0.5.0"
-pin-project = "1.1.3"
-bitflags = "2.4.2"
-axum-core = "0.4.3"
-futures-util = "0.3.30"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.45.0", features = ["Win32_Foundation"] }
 
 [dev-dependencies]
-hyper = "1.1.0"
+anyhow = "1.0.66"
+axum = { version = "0.7.4", features = ["tokio"] }
+flate2 = "1.0.25"
+hyper = { version = "1.1.0" }
 hyper-util = { version = "0.1.3", features = [
 	"tokio",
 	"server",
 	"http1",
 	"http2",
-] }
-tokio = { version = "1.23.0", features = ["full"] }
-anyhow = "1.0.66"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-reqwest = "0.11.13"
-flate2 = "1.0.25"
-tracing-test = "0.2.3"
-rand = "0.8.5"
+]}
 paste = "1.0.11"
-tokio-tungstenite = { version = "0.21.0", features = [
+rand = "0.8.5"
+reqwest = "0.12"
+tokio = { version = "1.23.0", features = ["full"] }
+tokio-tungstenite = { version = "0.26.2", features = [
 	"rustls",
 	"rustls-tls-webpki-roots",
 ] }
 tower = { version = "0.5", features = ["util"] }
-axum = { version = "0.7.4", features = ["tokio"] }
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+tracing-test = "0.2.3"
+
 
 [[example]]
 name = "tls"
@@ -91,8 +93,7 @@ name = "mingrok"
 required-features = ["hyper"]
 
 [features]
-default = []
-hyper = ["hyper/server", "hyper/http1"]
+hyper = ["hyper/server", "hyper/http1",  "dep:hyper"]
 axum = ["dep:axum", "hyper"]
 online-tests = ["axum", "hyper"]
 long-tests = ["online-tests"]

--- a/ngrok/src/online_tests.rs
+++ b/ngrok/src/online_tests.rs
@@ -1,5 +1,6 @@
 use std::{
     convert::Infallible,
+    error::Error,
     io,
     io::prelude::*,
     net::SocketAddr,
@@ -704,16 +705,37 @@ async fn tls() -> Result<(), BoxError> {
         .await?;
 
     let tun = start_http_server(tun, hello_router());
+    let url = tun.url.replacen("tls", "http", 1);
 
-    let url = tun.url.replacen("tls", "https", 1);
-
+    // Create a client with verbose logging and longer timeout
     let client = reqwest::Client::new();
+
     let resp = client.get(url.clone()).send().await;
 
     assert!(resp.is_err());
-    let err_str = resp.err().unwrap().to_string();
-    tracing::debug!(?err_str);
-    assert!(err_str.contains("certificate"));
+
+    let err = resp.err().unwrap();
+
+    // Check if the error is a certificate error
+    let is_certificate_error = if let Some(source) = err.source() {
+        // Try to downcast to hyper_util::client::legacy::Error
+        if let Some(hyper_error) = source.downcast_ref::<hyper_util::client::legacy::Error>() {
+            // Convert the entire error to a string to extract the message
+            let error_str = hyper_error.source().unwrap().to_string();
+
+            error_str.contains("certificate")
+        } else {
+            // If we can't downcast to the specific error type, fall back to string matching
+            let source_str = format!("{:?}", source);
+            assert!(source_str.contains("certificate"));
+            return Ok(());
+        }
+    } else {
+        // If there's no source, return an error
+        return Err("No error source found".into());
+    };
+
+    assert!(is_certificate_error);
 
     Ok(())
 }

--- a/ngrok/src/online_tests.rs
+++ b/ngrok/src/online_tests.rs
@@ -40,10 +40,6 @@ use hyper::{
     Request,
     Uri,
 };
-use hyper_0_14::{
-    header,
-    StatusCode,
-};
 use hyper_util::{
     rt::TokioExecutor,
     server,
@@ -55,6 +51,10 @@ use rand::{
     distributions::Alphanumeric,
     thread_rng,
     Rng,
+};
+use reqwest::{
+    header,
+    StatusCode,
 };
 use tokio::{
     io::{
@@ -565,7 +565,7 @@ macro_rules! proxy_proto_test {
 }
 
 proxy_proto_test!(
-    [(V1, &b"PROXY TCP4"[..]), (V2, &b"\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A"[..])]
+    [(V1, &b"PROXY TCP"[..]), (V2, &b"\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A"[..])]
     [
         (http, |tun| {
             reqwest::get(tun.url().to_string())

--- a/ngrok/src/online_tests.rs
+++ b/ngrok/src/online_tests.rs
@@ -705,7 +705,7 @@ async fn tls() -> Result<(), BoxError> {
 
     let tun = start_http_server(tun, hello_router());
 
-    let url = tun.url.replacen("tls", "http", 1);
+    let url = tun.url.replacen("tls", "https", 1);
 
     let client = reqwest::Client::new();
     let resp = client.get(url.clone()).send().await;

--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -40,7 +40,6 @@ use once_cell::sync::{
     OnceCell,
 };
 use regex::Regex;
-use rustls::crypto::CryptoProvider;
 use rustls_pemfile::Item;
 use thiserror::Error;
 use tokio::{
@@ -411,7 +410,6 @@ pub struct InvalidServerAddr(String);
 
 impl Default for SessionBuilder {
     fn default() -> Self {
-        CryptoProvider::get_default();
         SessionBuilder {
             versions: [(CLIENT_TYPE.to_string(), VERSION.to_string(), None)]
                 .into_iter()

--- a/ngrok/src/session.rs
+++ b/ngrok/src/session.rs
@@ -27,15 +27,12 @@ use futures_rustls::rustls::{
     pki_types,
     RootCertStore,
 };
-use hyper_0_14::{
-    client::HttpConnector,
-    service::Service,
-};
-use hyper_proxy::{
+use hyper_http_proxy::{
     Intercept,
     Proxy,
     ProxyConnector,
 };
+use hyper_util::client::legacy::connect::HttpConnector;
 use muxado::heartbeat::HeartbeatConfig;
 pub use muxado::heartbeat::HeartbeatHandler;
 use once_cell::sync::{
@@ -43,6 +40,7 @@ use once_cell::sync::{
     OnceCell,
 };
 use regex::Regex;
+use rustls::crypto::CryptoProvider;
 use rustls_pemfile::Item;
 use thiserror::Error;
 use tokio::{
@@ -68,6 +66,7 @@ use tokio_util::compat::{
     FuturesAsyncReadCompatExt,
     TokioAsyncReadCompatExt,
 };
+use tower_service::Service;
 use tracing::{
     debug,
     warn,
@@ -262,7 +261,8 @@ fn connect_http_proxy(url: Url) -> impl Connector {
             url.as_str().try_into().expect("urls should be valid uris"),
         );
         proxy.force_connect();
-        let connector = HttpConnector::new();
+        let mut connector = HttpConnector::new();
+        connector.enforce_http(false);
         async move {
             let mut connector = ProxyConnector::from_proxy(connector, proxy)
                 .map_err(|e| ConnectError::ProxyConnect(Box::new(e)))?;
@@ -274,14 +274,13 @@ fn connect_http_proxy(url: Url) -> impl Connector {
             let conn = connector
                 .call(server_uri)
                 .await
-                .map_err(|e| ConnectError::ProxyConnect(Box::new(e)))?
-                .compat();
+                .map_err(|e| ConnectError::ProxyConnect(Box::new(e)))?;
 
             let tls_conn = futures_rustls::TlsConnector::from(tls_config)
                 .connect(
                     pki_types::ServerName::try_from(host)
                         .expect("host should have been validated by SessionBuilder::server_addr"),
-                    conn,
+                    hyper_util::rt::TokioIo::new(conn).compat(),
                 )
                 .await
                 .map_err(ConnectError::Tls)?;
@@ -412,6 +411,7 @@ pub struct InvalidServerAddr(String);
 
 impl Default for SessionBuilder {
     fn default() -> Self {
+        CryptoProvider::get_default();
         SessionBuilder {
             versions: [(CLIENT_TYPE.to_string(), VERSION.to_string(), None)]
                 .into_iter()


### PR DESCRIPTION
Resolves #158 

### main.rs (example)
```rust
use ngrok::config::ForwarderBuilder;
use ngrok::tunnel::EndpointInfo;
use url::Url;

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
    connect_http_proxy().await?;
    Ok(())
}

async fn connect_http_proxy() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
    // Set up ngrok tunnel
    let sess = ngrok::Session::builder()
        .authtoken_from_env()
        .proxy_url(Url::parse("/* proxy url */").unwrap())?
        .root_cas("/* path to proxy certificate */")?
        .connect()
        .await?
        .http_endpoint()
        .domain("/* your reserved ngrok domain */")
        .listen_and_forward(Url::parse("/* your server url */").unwrap())
        .await?;

    println!("Ingress established at {:#?}", sess.url());
    // Wait indefinitely
    tokio::signal::ctrl_c().await?;
    Ok(())
}
```