### PR TITLE
feat(ngrok): add aws-lc-rs and ring features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,6 +2529,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",

--- a/ngrok/Cargo.toml
+++ b/ngrok/Cargo.toml
@@ -18,7 +18,7 @@ bitflags = "2.4.2"
 bytes = "1.3.0"
 
 futures = "0.3.25"
-futures-rustls = { version = "0.26.0" }
+futures-rustls = { version = "0.26.0", default-features = false, features = ["tls12", "logging"] }
 futures-util = "0.3.30"
 hostname = "0.3.1"
 hyper = { version = "^1.1.0", optional = true }
@@ -93,12 +93,15 @@ name = "mingrok"
 required-features = ["hyper"]
 
 [features]
+default = ["aws-lc-rs"]
 hyper = ["hyper/server", "hyper/http1",  "dep:hyper"]
 axum = ["dep:axum", "hyper"]
 online-tests = ["axum", "hyper"]
 long-tests = ["online-tests"]
 authenticated-tests = ["online-tests"]
 paid-tests = ["authenticated-tests"]
+aws-lc-rs = ["futures-rustls/aws-lc-rs"]
+ring = ["futures-rustls/ring"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Closes https://github.com/ngrok/ngrok-rust/issues/177

These features allow the consumer to choose between aws-lc-rs and ring rustls backends.