### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-doc-ngrok"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "awaitdrop",
  "axum",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "ngrok"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "arc-swap",


### PR DESCRIPTION
I forgot to actually run `cargo build` locally to update the locks when I put up #182, so the release failed. Fix it