### PR TITLE
workflows: fix publish action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ on:
     branches: [main]
   pull_request:
   workflow_call:
+    secrets:
+      NGROK_AUTHTOKEN:
+        required: true
 
 name: Continuous integration
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,8 @@ jobs:
   ci:
     name: Run CI
     uses: ./.github/workflows/ci.yml
+    secrets:
+      NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
 
   # Publishing jobs - these run sequentially as before
   publish-muxado:
@@ -18,7 +20,6 @@ jobs:
       crate: muxado
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
 
   publish-ngrok:
     name: Publish ngrok
@@ -31,7 +32,6 @@ jobs:
       crate: ngrok
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
 
   publish-cargo-doc-ngrok:
     name: Publish cargo-doc-ngrok
@@ -44,4 +44,3 @@ jobs:
       crate: cargo-doc-ngrok
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}


### PR DESCRIPTION
The secret wasn't needed for the release tasks, but rather for the CI task--which Visual Studio Code would've told me, but Helix did not.

I need to stop being hipster on this type of stuff and just drink the MS Koolaid.