### PR TITLE
[actions] only push a tag if it doesn't already exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,5 +37,10 @@ jobs:
           version="$(extract-crate-version ${{inputs.crate}})"
           git config user.name "GitHub Action"
           git config user.email noreply@ngrok.com
-          git tag -a -m "Version ${version}" ${{inputs.crate}}-v${version}
-          git push --tags
+          tag="${{inputs.crate}}-v${version}"
+          if git rev-parse "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists, skipping tag creation."
+          else
+            git tag -a -m "Version ${version}" $tag
+            git push --tags
+          fi


### PR DESCRIPTION
We should only publish an asset if the tag doesn't already exist, otherwise this step will fail.