### PR TITLE
[actions] Make sure grep doesn't return an error otherwise GHA will fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           crate="${{inputs.crate}}"
           tag="${crate}-v${version}"
           echo "Checking if crate $crate version $version exists on crates.io"
-          result=$(cargo search $crate --limit 1 | grep "$version")
+          result=$(cargo search $crate --limit 1 | grep "$version" || true)
           if [ -n "$result" ]; then
             echo "Crate $crate version $version already exists on crates.io, skipping publish."
             exit 0


### PR DESCRIPTION
These commands pass locally but fail in GHA because it interprets no results from grep as exit code 1 and fails the action. Instead this change will return true if grep fails and set result to an empty string. This allows the next if condition to run. In an empty string case we won't exit early and will push the new package. 