### PR TITLE
allow implicit bindings

### DIFF
--- a/ngrok/CHANGELOG.md
+++ b/ngrok/CHANGELOG.md
@@ -1,3 +1,19 @@
+## Unreleased
+
+### Breaking Changes
+- **Binding is now optional**: Tests no longer hardcode `binding("public")`. The ngrok service will use its default binding configuration when not explicitly specified.
+- **Binding validation**: The `binding()` method now validates input values and panics on invalid values or multiple calls.
+
+### Added
+- Added `Binding` enum with three variants: `Public`, `Internal`, and `Kubernetes`
+- Added validation for binding values - only "public", "internal", and "kubernetes" are accepted (case-insensitive)
+- Added `binding()` method documentation with examples for both string and typed enum usage
+- Added panic behavior when `binding()` is called more than once (only one binding allowed)
+
+### Changed
+- `binding()` method now accepts both strings and the `Binding` enum via `Into<String>`
+- Removed hardcoded "public" binding from all tests - bindings are now truly optional
+
 ## 0.15.0
 - - Removes `hyper-proxy` and `ring` dependencies 
 

--- a/ngrok/src/config/common.rs
+++ b/ngrok/src/config/common.rs
@@ -23,6 +23,69 @@ use crate::{
     Tunnel,
 };
 
+/// Represents the ingress configuration for an ngrok endpoint.
+///
+/// Bindings determine where and how your endpoint is exposed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Binding {
+    /// Publicly accessible endpoint (default for most configurations).
+    Public,
+    /// Internal-only endpoint, not accessible from the public internet.
+    Internal,
+    /// Kubernetes cluster binding for service mesh integration.
+    Kubernetes,
+}
+
+impl Binding {
+    /// Returns the string representation of this binding.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Binding::Public => "public",
+            Binding::Internal => "internal",
+            Binding::Kubernetes => "kubernetes",
+        }
+    }
+
+    /// Validates if a string is a recognized binding value.
+    pub(crate) fn validate(s: &str) -> Result<(), String> {
+        match s.to_lowercase().as_str() {
+            "public" | "internal" | "kubernetes" => Ok(()),
+            _ => Err(format!(
+                "Invalid binding value '{}'. Expected 'public', 'internal', or 'kubernetes'",
+                s
+            )),
+        }
+    }
+}
+
+impl From<Binding> for String {
+    fn from(binding: Binding) -> String {
+        binding.as_str().to_string()
+    }
+}
+
+impl std::str::FromStr for Binding {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "public" => Ok(Binding::Public),
+            "internal" => Ok(Binding::Internal),
+            "kubernetes" => Ok(Binding::Kubernetes),
+            _ => Err(format!(
+                "Invalid binding value '{}'. Expected 'public', 'internal', or 'kubernetes'",
+                s
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for Binding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
 pub(crate) fn default_forwards_to() -> &'static str {
     static FORWARDS_TO: OnceCell<String> = OnceCell::new();
 

--- a/ngrok/src/config/http.rs
+++ b/ngrok/src/config/http.rs
@@ -23,6 +23,7 @@ use crate::{
     config::{
         common::{
             default_forwards_to,
+            Binding,
             CommonOpts,
             TunnelConfig,
         },
@@ -261,9 +262,45 @@ impl HttpTunnelBuilder {
         self.options.common_opts.metadata = Some(metadata.into());
         self
     }
-    /// Sets the ingress configuration for this endpoint
+
+    /// Sets the ingress configuration for this endpoint.
+    ///
+    /// Valid binding values are:
+    /// - `"public"` - Publicly accessible endpoint
+    /// - `"internal"` - Internal-only endpoint
+    /// - `"kubernetes"` - Kubernetes cluster binding
+    ///
+    /// If not specified, the ngrok service will use its default binding configuration.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called more than once or if an invalid binding value is provided.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use ngrok::Session;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session = Session::builder().authtoken_from_env().connect().await?;
+    ///
+    /// // Using string
+    /// let tunnel = session.http_endpoint().binding("internal").listen().await?;
+    ///
+    /// // Using typed enum
+    /// use ngrok::config::Binding;
+    /// let tunnel = session.http_endpoint().binding(Binding::Public).listen().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn binding(&mut self, binding: impl Into<String>) -> &mut Self {
-        self.options.bindings.push(binding.into());
+        if !self.options.bindings.is_empty() {
+            panic!("binding() can only be called once");
+        }
+        let binding_str = binding.into();
+        if let Err(e) = Binding::validate(&binding_str) {
+            panic!("{}", e);
+        }
+        self.options.bindings.push(binding_str);
         self
     }
     /// Sets the ForwardsTo string for this tunnel. This can be viewed via the
@@ -482,7 +519,6 @@ impl HttpTunnelBuilder {
 mod test {
     use super::*;
     use crate::config::policies::test::POLICY_JSON;
-    const BINDING: &str = "public";
     const METADATA: &str = "testmeta";
     const TEST_FORWARD: &str = "testforward";
     const TEST_FORWARD_PROTO: &str = "http2";
@@ -509,7 +545,6 @@ mod test {
             .deny_cidr(DENY_CIDR)
             .proxy_proto(ProxyProto::V2)
             .metadata(METADATA)
-            .binding(BINDING)
             .scheme(Scheme::from_str("hTtPs").unwrap())
             .domain(DOMAIN)
             .mutual_tlsca(CA_CERT.into())
@@ -554,7 +589,7 @@ mod test {
         let extra = tunnel_cfg.extra();
         assert_eq!(String::default(), *extra.token);
         assert_eq!(METADATA, extra.metadata);
-        assert_eq!(Vec::from([BINDING]), extra.bindings);
+        assert_eq!(Vec::<String>::new(), extra.bindings);
         assert_eq!(String::default(), extra.ip_policy_ref);
 
         assert_eq!("https", tunnel_cfg.proto());
@@ -622,5 +657,62 @@ mod test {
         }
 
         assert_eq!(HashMap::new(), tunnel_cfg.labels());
+    }
+
+    #[test]
+    fn test_binding_valid_values() {
+        let mut builder = HttpTunnelBuilder {
+            session: None,
+            options: Default::default(),
+        };
+
+        // Test "public"
+        builder.binding("public");
+        assert_eq!(vec!["public"], builder.options.bindings);
+
+        // Test "internal"
+        let mut builder = HttpTunnelBuilder {
+            session: None,
+            options: Default::default(),
+        };
+        builder.binding("internal");
+        assert_eq!(vec!["internal"], builder.options.bindings);
+
+        // Test "kubernetes"
+        let mut builder = HttpTunnelBuilder {
+            session: None,
+            options: Default::default(),
+        };
+        builder.binding("kubernetes");
+        assert_eq!(vec!["kubernetes"], builder.options.bindings);
+
+        // Test with Binding enum
+        let mut builder = HttpTunnelBuilder {
+            session: None,
+            options: Default::default(),
+        };
+        builder.binding(Binding::Internal);
+        assert_eq!(vec!["internal"], builder.options.bindings);
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid binding value")]
+    fn test_binding_invalid_value() {
+        let mut builder = HttpTunnelBuilder {
+            session: None,
+            options: Default::default(),
+        };
+        builder.binding("invalid");
+    }
+
+    #[test]
+    #[should_panic(expected = "binding() can only be called once")]
+    fn test_binding_called_twice() {
+        let mut builder = HttpTunnelBuilder {
+            session: None,
+            options: Default::default(),
+        };
+        builder.binding("public");
+        builder.binding("internal");
     }
 }

--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -16,6 +16,7 @@ use crate::config::{
 use crate::{
     config::common::{
         default_forwards_to,
+        Binding,
         CommonOpts,
         TunnelConfig,
     },
@@ -143,9 +144,45 @@ impl TlsTunnelBuilder {
         self.options.common_opts.metadata = Some(metadata.into());
         self
     }
-    /// Sets the ingress configuration for this endpoint
+
+    /// Sets the ingress configuration for this endpoint.
+    ///
+    /// Valid binding values are:
+    /// - `"public"` - Publicly accessible endpoint
+    /// - `"internal"` - Internal-only endpoint
+    /// - `"kubernetes"` - Kubernetes cluster binding
+    ///
+    /// If not specified, the ngrok service will use its default binding configuration.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called more than once or if an invalid binding value is provided.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use ngrok::Session;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let session = Session::builder().authtoken_from_env().connect().await?;
+    ///
+    /// // Using string
+    /// let tunnel = session.tls_endpoint().binding("internal").listen().await?;
+    ///
+    /// // Using typed enum
+    /// use ngrok::config::Binding;
+    /// let tunnel = session.tls_endpoint().binding(Binding::Public).listen().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn binding(&mut self, binding: impl Into<String>) -> &mut Self {
-        self.options.bindings.push(binding.into());
+        if !self.options.bindings.is_empty() {
+            panic!("binding() can only be called once");
+        }
+        let binding_str = binding.into();
+        if let Err(e) = Binding::validate(&binding_str) {
+            panic!("{}", e);
+        }
+        self.options.bindings.push(binding_str);
         self
     }
     /// Sets the ForwardsTo string for this tunnel. This can be viewed via the
@@ -230,7 +267,6 @@ mod test {
     use super::*;
     use crate::config::policies::test::POLICY_JSON;
 
-    const BINDING: &str = "public";
     const METADATA: &str = "testmeta";
     const TEST_FORWARD: &str = "testforward";
     const ALLOW_CIDR: &str = "0.0.0.0/0";
@@ -254,7 +290,6 @@ mod test {
             .deny_cidr(DENY_CIDR)
             .proxy_proto(ProxyProto::V2)
             .metadata(METADATA)
-            .binding(BINDING)
             .domain(DOMAIN)
             .mutual_tlsca(CA_CERT.into())
             .mutual_tlsca(CA_CERT2.into())
@@ -275,7 +310,7 @@ mod test {
         let extra = tunnel_cfg.extra();
         assert_eq!(String::default(), *extra.token);
         assert_eq!(METADATA, extra.metadata);
-        assert_eq!(Vec::from([BINDING]), extra.bindings);
+        assert_eq!(Vec::<String>::new(), extra.bindings);
         assert_eq!(String::default(), extra.ip_policy_ref);
 
         assert_eq!("tls", tunnel_cfg.proto());
@@ -304,5 +339,62 @@ mod test {
         }
 
         assert_eq!(HashMap::new(), tunnel_cfg.labels());
+    }
+
+    #[test]
+    fn test_binding_valid_values() {
+        let mut builder = TlsTunnelBuilder {
+            session: None,
+            options: Default::default(),
+        };
+
+        // Test "public"
+        builder.binding("public");
+        assert_eq!(vec!["public"], builder.options.bindings);
+
+        // Test "internal"
+        let mut builder = TlsTunnelBuilder {
+            session: None,
+            options: Default::default(),
+        };
+        builder.binding("internal");
+        assert_eq!(vec!["internal"], builder.options.bindings);
+
+        // Test "kubernetes"
+        let mut builder = TlsTunnelBuilder {
+            session: None,
+            options: Default::default(),
+        };
+        builder.binding("kubernetes");
+        assert_eq!(vec!["kubernetes"], builder.options.bindings);
+
+        // Test with Binding enum
+        let mut builder = TlsTunnelBuilder {
+            session: None,
+            options: Default::default(),
+        };
+        builder.binding(Binding::Kubernetes);
+        assert_eq!(vec!["kubernetes"], builder.options.bindings);
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid binding value")]
+    fn test_binding_invalid_value() {
+        let mut builder = TlsTunnelBuilder {
+            session: None,
+            options: Default::default(),
+        };
+        builder.binding("invalid");
+    }
+
+    #[test]
+    #[should_panic(expected = "binding() can only be called once")]
+    fn test_binding_called_twice() {
+        let mut builder = TlsTunnelBuilder {
+            session: None,
+            options: Default::default(),
+        };
+        builder.binding("public");
+        builder.binding("internal");
     }
 }

--- a/ngrok/src/online_tests.rs
+++ b/ngrok/src/online_tests.rs
@@ -110,7 +110,6 @@ async fn tunnel() -> Result<(), BoxError> {
     let tun = setup_session()
         .await?
         .http_endpoint()
-        .binding("public")
         .metadata("Hello, world!")
         .forwards_to("some application")
         .listen()


### PR DESCRIPTION
ngrok now supports several different types of bindings (internal, public,and kubernetes), but we were forcing all bindings to be public, which is...not ideal.  This commit changes things so that bindings are no longer sent by default (which will allow ngrok to infer them), but can also optionally be specified.  The combination of these should fix not only .internal domains, but also allow the use of the Rust SDK in a Kubernetes context.