### PR TITLE
update the Rust SDK to use domains, not hostnames

### DIFF
--- a/ngrok/src/config/tls.rs
+++ b/ngrok/src/config/tls.rs
@@ -76,8 +76,7 @@ impl TunnelConfig for TlsOptions {
         let mut tls_endpoint = proto::TlsEndpoint::default();
 
         if let Some(domain) = self.domain.as_ref() {
-            // note: hostname and subdomain are going away in favor of just domain
-            tls_endpoint.hostname = domain.clone();
+            tls_endpoint.domain = domain.clone();
         }
         tls_endpoint.proxy_proto = self.common_opts.proxy_proto;
 
@@ -318,7 +317,7 @@ mod test {
         let opts = tunnel_cfg.opts().unwrap();
         assert!(matches!(opts, BindOpts::Tls { .. }));
         if let BindOpts::Tls(endpoint) = opts {
-            assert_eq!(DOMAIN, endpoint.hostname);
+            assert_eq!(DOMAIN, endpoint.domain);
             assert_eq!(String::default(), endpoint.subdomain);
             assert!(matches!(endpoint.proxy_proto, ProxyProto::V2));
             assert!(!endpoint.mutual_tls_at_agent);

--- a/ngrok/src/internals/proto.rs
+++ b/ngrok/src/internals/proto.rs
@@ -672,6 +672,8 @@ impl From<String> for PolicyWrapper {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "PascalCase")]
 pub struct HttpEndpoint {
+    #[serde(default)]
+    pub domain: String,
     pub hostname: String,
     pub auth: String,
     pub subdomain: String,
@@ -833,6 +835,8 @@ pub struct TcpEndpoint {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "PascalCase")]
 pub struct TlsEndpoint {
+    #[serde(default)]
+    pub domain: String,
     pub hostname: String,
     pub subdomain: String,
     pub proxy_proto: ProxyProto,


### PR DESCRIPTION
Hostnames kept working for awhile because ngrok does have backcompat for it, hostnames don't go through codepaths that enable internal or kubernetes bindings. Fix that by cutting over to domains.