### PR TITLE
Fix CI and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,25 +63,6 @@ jobs:
           command: test
           args: --workspace --all-targets
 
-  test-stable:
-    name: Test Stable
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      # We don't actually have sccache installed here (yet), but it still
-      # benefits from the cargo cache.
-      - uses: ./.github/workflows/rust-cache
-      - uses: actions-rs/cargo@v1
-        env:
-          NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
-        with:
-          command: test
-          args: --features=paid-tests,long-tests --workspace --all-targets
 
   test-win:
     name: Test Windows Stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   udeps:
     name: Udeps
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: jrobsonchase/direnv-action@v0.7
@@ -25,6 +26,7 @@ jobs:
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: jrobsonchase/direnv-action@v0.7
@@ -36,6 +38,7 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: jrobsonchase/direnv-action@v0.7
@@ -48,6 +51,7 @@ jobs:
   test-nix:
     name: Test Nix
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: jrobsonchase/direnv-action@v0.7
@@ -82,6 +86,7 @@ jobs:
   test-win:
     name: Test Windows Stable
     runs-on: windows-latest
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
@@ -102,6 +107,7 @@ jobs:
   semver:
     name: Semver Check
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         crate: [muxado, ngrok]

--- a/.github/workflows/online-tests.yml
+++ b/.github/workflows/online-tests.yml
@@ -1,0 +1,43 @@
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_call:
+    secrets:
+      NGROK_AUTHTOKEN:
+        required: true
+
+name: Online tests
+
+# These tests exercise the live ngrok service (paid + long-running suites in
+# ngrok/src/online_tests.rs). They are inherently flaky against a real backend,
+# so they live in their own workflow and are intentionally NOT part of the
+# release gate (publish.yml -> ci.yml): a service blip must never be able to
+# wedge a publish. The online tests still run on every push/PR as their own
+# check.
+
+jobs:
+  test-stable:
+    name: Test Stable (online)
+    runs-on: ubuntu-latest
+    # The online tests have no in-test timeouts and `cargo test` can't bound an
+    # individual test, so a stuck network call would otherwise hang until
+    # GitHub's 6h default. This job-level cap is the backstop that keeps a hang
+    # to a few minutes.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      # We don't actually have sccache installed here (yet), but it still
+      # benefits from the cargo cache.
+      - uses: ./.github/workflows/rust-cache
+      - uses: actions-rs/cargo@v1
+        env:
+          NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
+        with:
+          command: test
+          args: --features=paid-tests,long-tests --workspace --all-targets

--- a/ngrok/src/online_tests.rs
+++ b/ngrok/src/online_tests.rs
@@ -12,7 +12,10 @@ use std::{
             Ordering,
         },
     },
-    time::Duration,
+    time::{
+        Duration,
+        Instant,
+    },
 };
 
 use anyhow::anyhow;
@@ -195,9 +198,31 @@ fn hello_router() -> Router {
 }
 
 async fn check_body(url: impl AsRef<str>, expected: impl AsRef<str>) -> Result<(), BoxError> {
-    let body: String = reqwest::get(url.as_ref()).await?.text().await?;
-    assert_eq!(body, expected.as_ref());
-    Ok(())
+    let url = url.as_ref();
+    let expected = expected.as_ref();
+
+    // A freshly-created endpoint isn't always immediately routable at the ngrok
+    // edge: for a brief window after `listen()` returns, a request can race
+    // ahead of the endpoint coming online and get served the edge's
+    // "endpoint offline" (ERR_NGROK_3200) page instead of our backend. Poll for
+    // a short budget so that startup race doesn't flake the test; a genuinely
+    // wrong body still fails (with the usual assert diff) once the budget runs
+    // out.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        match reqwest::get(url).await {
+            Ok(resp) => {
+                let body = resp.text().await?;
+                if body == expected || Instant::now() >= deadline {
+                    assert_eq!(body, expected);
+                    return Ok(());
+                }
+            }
+            Err(e) if Instant::now() >= deadline => return Err(e.into()),
+            Err(_) => {}
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
 }
 
 #[cfg_attr(not(feature = "online-tests"), ignore)]


### PR DESCRIPTION
This entire PR really is just setting timeouts on everything to avoid super slow CI runs. It also avoids gating publish on CI passing, since we've had one too many cases of CI passing on the PR but failing in the publish run, which blocks publish